### PR TITLE
Modified Strehlow to use unified material specs

### DIFF
--- a/gemd/demo/strehlow_and_cook.py
+++ b/gemd/demo/strehlow_and_cook.py
@@ -225,12 +225,12 @@ def make_strehlow_objects(table=None):
     for row in table:
         formula = formula_clean(row['chemicalFormula'])
         if formula not in compounds:
-            compounds[formula] = MaterialSpec(name=formula_latex(formula),
-                                              template=tmpl["Chemical"],
-                                              process=ProcessSpec(name="Sample preparation",
-                                                                  template=tmpl["Sample preparation"]
-                                                                  )
-                                              )
+            compounds[formula] = MaterialSpec(
+                name=formula_latex(formula),
+                template=tmpl["Chemical"],
+                process=ProcessSpec(name="Sample preparation",
+                                    template=tmpl["Sample preparation"]
+                                    ))
         spec = compounds[formula]
         run = make_instance(spec)
         datapoints.append(run)

--- a/gemd/demo/strehlow_and_cook.py
+++ b/gemd/demo/strehlow_and_cook.py
@@ -224,13 +224,14 @@ def make_strehlow_objects(table=None):
     compounds = dict()
     for row in table:
         formula = formula_clean(row['chemicalFormula'])
-        spec = compounds.get(formula,
-                             MaterialSpec(name=formula_latex(formula),
-                                          template=tmpl["Chemical"],
-                                          process=ProcessSpec(name="Sample preparation",
-                                                              template=tmpl["Sample preparation"]
-                                                              )
-                                          ))
+        if formula not in compounds:
+            compounds[formula] = MaterialSpec(name=formula_latex(formula),
+                                              template=tmpl["Chemical"],
+                                              process=ProcessSpec(name="Sample preparation",
+                                                                  template=tmpl["Sample preparation"]
+                                                                  )
+                                              )
+        spec = compounds[formula]
         run = make_instance(spec)
         datapoints.append(run)
 

--- a/gemd/demo/tests/test_sac.py
+++ b/gemd/demo/tests/test_sac.py
@@ -14,6 +14,12 @@ def test_sac():
     for comp in sac:
         assert je.loads(je.dumps(comp)) == comp
 
+    # Verify that specs are shared when compounds match
+    for comp1 in sac:
+        for comp2 in sac:
+            # xand
+            assert (comp1.name == comp2.name) == (comp1.spec.uids == comp2.spec.uids)
+
     # Look at each different combination of Value types in a S&C record
     smaller = minimal_subset(sac_tbl['content'])
     # Make sure that the diversity of value types isn't lost, e.g. something is being None'd

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='gemd',
-      version='0.6.2',
+      version='0.6.3',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',


### PR DESCRIPTION
Correcting bug where Strehlow and Cook demo was creating a new Material Spec for every row instead of reusing the same spec for replicate chemical formulas.