### PR TITLE
Add molecular structure types to cake example

### DIFF
--- a/gemd/demo/cake.py
+++ b/gemd/demo/cake.py
@@ -685,9 +685,10 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
                                std=0.05 * item.spec.absolute_quantity.nominal,
                                units=item.spec.absolute_quantity.units)
             if item.spec.volume_fraction is not None:
+                # The only element here is dry mix, and it's almost entirely flour
                 item.volume_fraction = \
-                    NormalReal(mean=fuzz * item.spec.volume_fraction.nominal,
-                               std=0.05 * item.spec.volume_fraction.nominal,
+                    NormalReal(mean=0.01 * (fuzz - 0.5) + item.spec.volume_fraction.nominal,
+                               std=0.005,
                                units=item.spec.volume_fraction.units)
             if item.spec.mass_fraction is not None:
                 item.mass_fraction = \

--- a/gemd/demo/cake.py
+++ b/gemd/demo/cake.py
@@ -441,7 +441,9 @@ def make_cake_spec(tmpl=None):
         properties=[
             PropertyAndConditions(Property(name='Formula', value=EmpiricalFormula("NaCl"))),
             PropertyAndConditions(
-                Property(name='InChI', value=InChI("InChI=1S/ClH.Na/h1H;/q;+1/p-1"))
+                Property(name='InChI',
+                         value=InChI("InChI=1S/ClH.Na/h1H;/q;+1/p-1"),
+                         template=tmpl["Molecular Structure"])
             )
         ]
     )
@@ -470,7 +472,9 @@ def make_cake_spec(tmpl=None):
             PropertyAndConditions(Property(name="Formula", value=EmpiricalFormula("C12H22O11"))),
             PropertyAndConditions(
                 Property(name='SMILES',
-                         value=Smiles("C(C1C(C(C(C(O1)OC2(C(C(C(O2)CO)O)O)CO)O)O)O)O"))
+                         value=Smiles("C(C1C(C(C(C(O1)OC2(C(C(C(O2)CO)O)O)CO)O)O)O)O"),
+                         template=tmpl["Molecular Structure"]
+                         )
             )
         ]
     )

--- a/gemd/demo/cake.py
+++ b/gemd/demo/cake.py
@@ -4,7 +4,8 @@ import json
 import random
 
 from gemd.entity.attribute import Condition, Parameter, Property, PropertyAndConditions
-from gemd.entity.bounds import IntegerBounds, RealBounds, CategoricalBounds, CompositionBounds
+from gemd.entity.bounds import IntegerBounds, RealBounds, CategoricalBounds, CompositionBounds, \
+    MolecularStructureBounds
 from gemd.entity.object import ProcessSpec, ProcessRun, MaterialSpec, MaterialRun, \
     MeasurementSpec, MeasurementRun, IngredientSpec, IngredientRun
 from gemd.entity.template import ProcessTemplate, MaterialTemplate, MeasurementTemplate, \
@@ -12,7 +13,8 @@ from gemd.entity.template import ProcessTemplate, MaterialTemplate, MeasurementT
 from gemd.entity.value import NominalInteger, UniformInteger, \
     NominalReal, NormalReal, UniformReal, \
     NominalCategorical, DiscreteCategorical, \
-    NominalComposition, EmpiricalFormula
+    NominalComposition, EmpiricalFormula, \
+    Smiles, InChI
 from gemd.enumeration.origin import Origin
 
 from gemd.entity.util import complete_material_history, make_instance
@@ -113,6 +115,11 @@ def make_cake_templates():
         description="The chemical formula of a material",
         bounds=CompositionBounds(components=EmpiricalFormula.all_elements())
     )
+    tmpl["Molecular Structure"] = PropertyTemplate(
+        name="Molecular Structure",
+        description="The molecular structure of the material",
+        bounds=MolecularStructureBounds()
+    )
 
     # Objects
     tmpl["Baking in an oven"] = ProcessTemplate(
@@ -165,7 +172,8 @@ def make_cake_templates():
         name="Formulaic Material",
         description="A material with chemical characterization",
         properties=[
-            tmpl["Chemical Formula"]
+            tmpl["Chemical Formula"],
+            tmpl["Molecular Structure"]
         ]
     )
     tmpl["Icing"] = ProcessTemplate(name="Icing",
@@ -431,7 +439,10 @@ def make_cake_spec(tmpl=None):
         ],
         notes='Plain old NaCl',
         properties=[
-            PropertyAndConditions(Property(name='Formula', value=EmpiricalFormula("NaCl")))
+            PropertyAndConditions(Property(name='Formula', value=EmpiricalFormula("NaCl"))),
+            PropertyAndConditions(
+                Property(name='InChI', value=InChI("InChI=1S/ClH.Na/h1H;/q;+1/p-1"))
+            )
         ]
     )
     IngredientSpec(
@@ -456,7 +467,11 @@ def make_cake_spec(tmpl=None):
         ],
         notes='Sugar',
         properties=[
-            PropertyAndConditions(Property(name="Formula", value=EmpiricalFormula("C12H22O11")))
+            PropertyAndConditions(Property(name="Formula", value=EmpiricalFormula("C12H22O11"))),
+            PropertyAndConditions(
+                Property(name='SMILES',
+                         value=Smiles("C(C1C(C(C(C(O1)OC2(C(C(C(O2)CO)O)O)CO)O)O)O)O"))
+            )
         ]
     )
     IngredientSpec(

--- a/gemd/demo/tests/test_cake.py
+++ b/gemd/demo/tests/test_cake.py
@@ -39,12 +39,12 @@ def test_cake():
         tot_count += 1
 
     recursive_foreach(cake, increment)
-    assert tot_count == 130
+    assert tot_count == 131
 
     # And make sure nothing was lost
     tot_count = 0
     recursive_foreach(loads(dumps(complete_material_history(cake))), increment)
-    assert tot_count == 130
+    assert tot_count == 131
 
     # Check that no UIDs collide
     uid_seen = dict()

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='gemd',
-      version='0.7.1',
+      version='0.7.2',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',


### PR DESCRIPTION
Molecular structure types were added to the cake example.  In particular, for the two items that already had expected molecular structures, a SMILES was added to sugar and an InChI was added to salt, both using the same Molecular Structure bounds object.

This is expected to be a proper release.

https://citrine.atlassian.net/browse/PLA-3934
