### PR TITLE
Remove unnecessary enumeration library (>=3.5)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 toolz==0.10.0
-enum34==1.1.6
 pint==0.9
 strip-hints==0.1.7
 sphinx==2.2.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='gemd',
-      version='0.7.3',
+      version='0.7.4',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',
@@ -54,7 +54,6 @@ setup(name='gemd',
       install_requires=[
           "toolz",
           "pytest>=4.3",
-          "enum34",
           "pint>=0.9",
           "strip-hints>=0.1.5",
           "deprecation>=2.0.7,<3"


### PR DESCRIPTION
With the migration to supporting 3.5 and later, we no longer need the enum34 library.  The library was still listed in the requirements files, so this removes those obsolete lines with no change in functionality.