### PR TITLE
Modified unit defaults to reduce risks

### DIFF
--- a/gemd/units/citrine_en.txt
+++ b/gemd/units/citrine_en.txt
@@ -339,7 +339,7 @@ bar = 1e5 * pascal
 technical_atmosphere = kilogram * g_0 / centimeter ** 2 = at
 torr = atm / 760
 pound_force_per_square_inch = force_pound / inch ** 2 = psi
-kip_per_square_inch = kip / inch ** 2 = _ = kip_per_square_inch
+kip_per_square_inch = kip / inch ** 2 = ksi
 millimeter_Hg = millimeter * Hg * g_0 = mmHg = mm_Hg = millimeter_Hg_0C
 centimeter_Hg = centimeter * Hg * g_0 = cmHg = cm_Hg = centimeter_Hg_0C
 inch_Hg = inch * Hg * g_0 = inHg = in_Hg = inch_Hg_32F

--- a/gemd/units/citrine_en.txt
+++ b/gemd/units/citrine_en.txt
@@ -202,12 +202,12 @@ angstrom_star = K_alpha_W_d_220 * d_220 / 0.2090100 = Å_star
 planck_length = (hbar * gravitational_constant / c ** 3) ** 0.5
 
 # Mass
-metric_ton = 1e3 * kilogram = t = tonne
-unified_atomic_mass_unit = atomic_mass_constant = u = amu
+metric_ton = 1e3 * kilogram = _ = tonne
+unified_atomic_mass_unit = atomic_mass_constant = _ = amu
 dalton = atomic_mass_constant = Da
 grain = 64.79891 * milligram = gr
 gamma_mass = microgram
-carat = 200 * milligram = ct = karat
+carat = 200 * milligram = _ = karat
 planck_mass = (hbar * c / gravitational_constant) ** 0.5
 
 # Time
@@ -216,7 +216,7 @@ hour = 60 * minute = hr
 day = 24 * hour = d
 week = 7 * day
 fortnight = 2 * week
-year = 365.25 * day = a = yr = julian_year
+year = 365.25 * day = yr = julian_year
 month = year / 12
 decade = 10 * year
 century = 100 * year = _ = centuries
@@ -287,7 +287,7 @@ newton = kilogram * meter / second ** 2 = N
 dyne = gram * centimeter / second ** 2 = dyn
 force_kilogram = g_0 * kilogram = kgf = kilogram_force = pond
 force_gram = g_0 * gram = gf = gram_force
-force_metric_ton = g_0 * metric_ton = tf = metric_ton_force = force_t = t_force
+force_metric_ton = g_0 * metric_ton = _ = metric_ton_force = force_t = t_force
 atomic_unit_of_force = E_h / a_0 = a_u_force
 
 # Energy
@@ -339,7 +339,7 @@ bar = 1e5 * pascal
 technical_atmosphere = kilogram * g_0 / centimeter ** 2 = at
 torr = atm / 760
 pound_force_per_square_inch = force_pound / inch ** 2 = psi
-kip_per_square_inch = kip / inch ** 2 = ksi
+kip_per_square_inch = kip / inch ** 2 = _ = kip_per_square_inch
 millimeter_Hg = millimeter * Hg * g_0 = mmHg = mm_Hg = millimeter_Hg_0C
 centimeter_Hg = centimeter * Hg * g_0 = cmHg = cm_Hg = centimeter_Hg_0C
 inch_Hg = inch * Hg * g_0 = inHg = in_Hg = inch_Hg_32F
@@ -380,7 +380,7 @@ enzyme_unit = micromole / minute = U = enzymeunit
 
 # Entropy
 [entropy] = [energy] / [temperature]
-clausius = calorie / kelvin = Cl
+clausius = calorie / kelvin = _ = clausius
 
 # Molar entropy
 [molar_entropy] = [entropy] / [substance]
@@ -492,7 +492,7 @@ gamma = 1e-9 * tesla = γ
 [magnetomotive_force] = [current]
 ampere_turn = ampere = At
 biot_turn = biot
-gilbert = 1 / (4 * π) * biot_turn = Gb
+gilbert = 1 / (4 * π) * biot_turn = _ = gilbert
 
 # Magnetic field strength
 [magnetic_field_strength] = [current] / [length]
@@ -534,29 +534,29 @@ nuclear_magneton = e * hbar / (2 * m_p) = µ_N = mu_N
     cubic_yard = yd ** 3 = cu_yd
 @end
 
-@group USCSLengthSurvey
-    link = 1e-2 * chain = li = survey_link
-    survey_foot = 1200 / 3937 * meter = sft
-    fathom = 6 * survey_foot
-    rod = 16.5 * survey_foot = rd = pole = perch
-    chain = 4 * rod
-    furlong = 40 * rod = fur
-    cables_length = 120 * fathom
-    survey_mile = 5280 * survey_foot = smi = us_statute_mile
-    league = 3 * survey_mile
-
-    square_rod = rod ** 2 = sq_rod = sq_pole = sq_perch
-    acre = 10 * chain ** 2
-    square_survey_mile = survey_mile ** 2 = _ = section
-    square_league = league ** 2
-
-    acre_foot = acre * survey_foot = _ = acre_feet
-@end
+# @group USCSLengthSurvey
+#     link = 1e-2 * chain = li = survey_link
+#     survey_foot = 1200 / 3937 * meter = sft
+#     fathom = 6 * survey_foot
+#     rod = 16.5 * survey_foot = rd = pole = perch
+#     chain = 4 * rod
+#     furlong = 40 * rod = fur
+#     cables_length = 120 * fathom
+#     survey_mile = 5280 * survey_foot = smi = us_statute_mile
+#     league = 3 * survey_mile
+#
+#     square_rod = rod ** 2 = sq_rod = sq_pole = sq_perch
+#     acre = 10 * chain ** 2
+#     square_survey_mile = survey_mile ** 2 = _ = section
+#     square_league = league ** 2
+#
+#     acre_foot = acre * survey_foot = _ = acre_feet
+# @end
 
 @group USCSDryVolume
-    dry_pint = bushel / 64 = dpi = US_dry_pint
-    dry_quart = bushel / 32 = dqt = US_dry_quart
-    dry_gallon = bushel / 8 = dgal = US_dry_gallon
+    dry_pint = bushel / 64 = _ = US_dry_pint
+    dry_quart = bushel / 32 = _ = US_dry_quart
+    dry_gallon = bushel / 8 = _ = US_dry_gallon
     peck = bushel / 4 = pk
     bushel = 2150.42 cubic_inch = bu
     dry_barrel = 7056 cubic_inch = _ = US_dry_barrel
@@ -565,7 +565,7 @@ nuclear_magneton = e * hbar / (2 * m_p) = µ_N = mu_N
 
 @group USCSLiquidVolume
     minim = pint / 7680
-    fluid_dram = pint / 128 = fldr = fluidram = US_fluid_dram = US_liquid_dram
+    fluid_dram = pint / 128 = _ = fluidram = US_fluid_dram = US_liquid_dram
     fluid_ounce = pint / 16 = floz = US_fluid_ounce = US_liquid_ounce
     gill = pint / 4 = gi = liquid_gill = US_liquid_gill
     pint = quart / 2 = pt = liquid_pint = US_pint
@@ -578,7 +578,7 @@ nuclear_magneton = e * hbar / (2 * m_p) = µ_N = mu_N
     teaspoon = fluid_ounce / 6 = tsp
     tablespoon = fluid_ounce / 2 = tbsp
     shot = 3 * tablespoon = jig = US_shot
-    cup = pint / 2 = cp = liquid_cup = US_liquid_cup
+    cup = pint / 2 = _ = liquid_cup = US_liquid_cup
     barrel = 31.5 * gallon = bbl
     oil_barrel = 42 * gallon = oil_bbl
     beer_barrel = 31 * gallon = beer_bbl
@@ -586,7 +586,7 @@ nuclear_magneton = e * hbar / (2 * m_p) = µ_N = mu_N
 @end
 
 @group Avoirdupois
-    dram = pound / 256 = dr = avoirdupois_dram = avdp_dram = drachm
+    dram = pound / 256 = _ = avoirdupois_dram = avdp_dram = drachm
     ounce = pound / 16 = oz = avoirdupois_ounce = avdp_ounce
     pound = 7e3 * grain = lb = avoirdupois_pound = avdp_pound
     stone = 14 * pound
@@ -619,9 +619,9 @@ nuclear_magneton = e * hbar / (2 * m_p) = µ_N = mu_N
 @end
 
 @group Troy
-    pennyweight = 24 * grain = dwt
-    troy_ounce = 480 * grain = toz = ozt
-    troy_pound = 12 * troy_ounce = tlb = lbt
+    pennyweight = 24 * grain = _ = pennyweight
+    troy_ounce = 480 * grain = _ = troy_ounce
+    troy_pound = 12 * troy_ounce = _ = troy_pound
 @end
 
 @group Apothecary
@@ -648,7 +648,7 @@ nuclear_magneton = e * hbar / (2 * m_p) = µ_N = mu_N
 
 @group Printer
     pica = inch / 6 = _ = printers_pica
-    point = pica / 12 = pp = printers_point = big_point = bp
+    point = pica / 12 = _ = printers_point = big_point
     didot = 1 / 2660 * m
     cicero = 12 * didot
     tex_point = inch / 72.27
@@ -664,17 +664,17 @@ nuclear_magneton = e * hbar / (2 * m_p) = µ_N = mu_N
     bits_per_pixel = bit / pixel = bpp
 @end
 
-@group Textile
-    tex = gram / kilometer = Tt
-    dtex = decitex
-    denier = gram / (9 * kilometer) = den = Td
-    jute = pound / (14400 * yard) = Tj
-    aberdeen = jute = Ta
-    RKM = kgf * 1000 / tex
-
-    number_english = 840 * yard / pound = Ne = NeC = ECC
-    number_meter = kilometer / kilogram = Nm
-@end
+# @group Textile
+#     tex = gram / kilometer = Tt
+#     dtex = decitex
+#     denier = gram / (9 * kilometer) = den = Td
+#     jute = pound / (14400 * yard) = Tj
+#     aberdeen = jute = Ta
+#     RKM = kgf * 1000 / tex
+#
+#     number_english = 840 * yard / pound = Ne = NeC = ECC
+#     number_meter = kilometer / kilogram = Nm
+# @end
 
 
 #### CGS ELECTROMAGNETIC UNITS ####

--- a/gemd/units/tests/test_parser.py
+++ b/gemd/units/tests/test_parser.py
@@ -16,7 +16,8 @@ def test_parse_expected():
         "inch", "ft", "mm", "um",
         "second", "ms", "hour", "minute", "ns",
         "g/cm^3", "g/mL", "kg/cm^3",
-        _ureg("kg").u
+        _ureg("kg").u,
+        "amu"  # A line that was edited
     ]
     for unit in expected:
         parse_units(unit)
@@ -26,7 +27,9 @@ def test_parse_unexpected():
     """Test that we cannot parse the units that we do not expect to."""
     unexpected = [
         "gibberish",
-        5
+        5,
+        "cp",  # Removed because of risk of collision with cP
+        "chain"  # Survey units eliminated
     ]
     for unit in unexpected:
         with pytest.raises(UndefinedUnitError):

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='gemd',
-      version='0.8.0',
+      version='0.8.1',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',


### PR DESCRIPTION
This reduces the number of short aliases for units in an attempt to be a bit less likely to yield unfortunate results.  Motivated by an attempt to enter centipoise (cP) and getting cups.  

When a line includes an underscore, the first term in the line is used to describe the unit.  For example:

`unified_atomic_mass_unit = atomic_mass_constant = _ = amu`

will represent a value as `5.0 unified_atomic_mass_unit` and display that upon request.  When the underscore is not present, the third term is used as the alias: 

`dalton = atomic_mass_constant = Da`

will represent a value as `5.0 Da`.