### PR TITLE
PLA-2151 make bounds optional on object templates

### DIFF
--- a/gemd/entity/template/base_template.py
+++ b/gemd/entity/template/base_template.py
@@ -59,7 +59,8 @@ class BaseTemplate(BaseEntity):
         # check that the bounds is consistent with that of the template
         elif isinstance(template_or_tuple, (tuple, list)):
             first, second = template_or_tuple
-            if isinstance(first, (LinkByUID, AttributeTemplate)) and (isinstance(second, BaseBounds) or second is None):
+            if isinstance(first, (LinkByUID, AttributeTemplate)) and \
+                    (isinstance(second, BaseBounds) or second is None):
                 if isinstance(first, AttributeTemplate) and isinstance(second, BaseBounds):
                     if not first.bounds.contains(second):
                         raise ValueError("Range and template are inconsistent")

--- a/gemd/entity/template/base_template.py
+++ b/gemd/entity/template/base_template.py
@@ -52,18 +52,16 @@ class BaseTemplate(BaseEntity):
             when used in the context of **this** object.
 
         """
-        # if given a template, pull out its bounds
-        if isinstance(template_or_tuple, AttributeTemplate):
-            return [template_or_tuple, template_or_tuple.bounds]
+        # if given a template only, use None to represent passthrough bounds
+        if isinstance(template_or_tuple, (AttributeTemplate, LinkByUID)):
+            return [template_or_tuple, None]
         # if given a (template, bounds) pair,
         # check that the bounds is consistent with that of the template
         elif isinstance(template_or_tuple, (tuple, list)):
             first, second = template_or_tuple
-            if isinstance(first, LinkByUID) and isinstance(second, BaseBounds):
+            if isinstance(first, (LinkByUID, AttributeTemplate)) and (isinstance(second, BaseBounds) or second is None):
+                if isinstance(first, AttributeTemplate) and isinstance(second, BaseBounds):
+                    if not first.bounds.contains(second):
+                        raise ValueError("Range and template are inconsistent")
                 return [first, second]
-            if isinstance(first, AttributeTemplate) and isinstance(second, BaseBounds):
-                if first.bounds.contains(second):
-                    return [first, second]
-                else:
-                    raise ValueError("Range and template are inconsistent")
         raise TypeError("Expected a template or (template, bounds) tuple")  # pragma: no cover

--- a/gemd/entity/template/has_condition_templates.py
+++ b/gemd/entity/template/has_condition_templates.py
@@ -1,4 +1,5 @@
 """For entities that have a condition template."""
+from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.setters import validate_list
 from gemd.entity.template.base_template import BaseTemplate
 from gemd.entity.template.condition_template import ConditionTemplate
@@ -34,7 +35,7 @@ class HasConditionTemplates(object):
 
     @conditions.setter
     def conditions(self, conditions):
-        lst = validate_list(conditions, (ConditionTemplate, list, tuple))
+        lst = validate_list(conditions, (ConditionTemplate, LinkByUID, list, tuple))
 
         # make sure attribute can be a Condition
         # TODO: list.map(_.validate_scope(AttributeType.CONDITION)) all true

--- a/gemd/entity/template/has_parameter_templates.py
+++ b/gemd/entity/template/has_parameter_templates.py
@@ -1,4 +1,5 @@
 """For entities that have a parameter template."""
+from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.setters import validate_list
 from gemd.entity.template.base_template import BaseTemplate
 from gemd.entity.template.parameter_template import ParameterTemplate
@@ -34,7 +35,7 @@ class HasParameterTemplates(object):
 
     @parameters.setter
     def parameters(self, parameters):
-        lst = validate_list(parameters, (ParameterTemplate, list, tuple))
+        lst = validate_list(parameters, (ParameterTemplate, LinkByUID, list, tuple))
 
         # make sure attribute can be a Parameter
         # TODO: list.map(_.validate_scope(AttributeType.PARAMETER)) all true

--- a/gemd/entity/template/has_property_templates.py
+++ b/gemd/entity/template/has_property_templates.py
@@ -1,4 +1,5 @@
 """For entities that have a property template."""
+from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.setters import validate_list
 from gemd.entity.template.base_template import BaseTemplate
 from gemd.entity.template.property_template import PropertyTemplate
@@ -35,7 +36,7 @@ class HasPropertyTemplates(object):
     @properties.setter
     def properties(self, properties):
         # make sure the properties are a list
-        lst = validate_list(properties, (PropertyTemplate, list, tuple))
+        lst = validate_list(properties, (PropertyTemplate, LinkByUID, list, tuple))
 
         # make sure attribute can be a Property
         # TODO: list.map(_.validate_scope(AttributeType.PROPERTY)) all true

--- a/gemd/entity/template/tests/test_process_template.py
+++ b/gemd/entity/template/tests/test_process_template.py
@@ -45,7 +45,7 @@ def test_allowed_labels():
 
 
 def test_passthrough_bounds():
-    """Test that unspecified Bounds are accepted and set to None"""
+    """Test that unspecified Bounds are accepted and set to None."""
     template = ProcessTemplate('foo', conditions=[
         (LinkByUID('1', '2'), None),
         [LinkByUID('3', '4'), None],

--- a/gemd/entity/template/tests/test_process_template.py
+++ b/gemd/entity/template/tests/test_process_template.py
@@ -1,9 +1,12 @@
 """Tests of the ProcessTemplate object."""
 import pytest
 
+from gemd.entity.bounds import IntegerBounds
+from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.template.process_template import ProcessTemplate
 from gemd.entity.template.condition_template import ConditionTemplate
 from gemd.entity.bounds.real_bounds import RealBounds
+from gemd.json import dumps, loads
 
 
 def test_bounds_mismatch():
@@ -39,3 +42,35 @@ def test_allowed_labels():
     proc_template = ProcessTemplate(name="test template", allowed_labels=allowed_labels)
     for label in allowed_labels:
         assert label in proc_template.allowed_labels
+
+
+def test_passthrough_bounds():
+    """Test that unspecified Bounds are accepted and set to None"""
+    template = ProcessTemplate('foo', conditions=[
+        (LinkByUID('1', '2'), None),
+        [LinkByUID('3', '4'), None],
+        LinkByUID('5', '6'),
+        ConditionTemplate('foo', bounds=IntegerBounds(0, 10)),
+    ])
+    assert len(template.conditions) == 4
+    for _, bounds in template.conditions:
+        assert bounds is None
+    copied = loads(dumps(template))
+    assert len(copied.conditions) == 4
+    for _, bounds in copied.conditions:
+        assert bounds is None
+    from_dict = ProcessTemplate.build({
+        'type': 'process_template',
+        'name': 'foo',
+        'conditions': [
+            [
+                {
+                    'scope': 'foo',
+                    'id': 'bar',
+                    'type': 'link_by_uid',
+                },
+                None,
+            ]
+        ],
+    })
+    assert len(from_dict.conditions) == 1

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='gemd',
-      version='0.8.1',
+      version='0.9.0',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',


### PR DESCRIPTION
* Bounds are now optional on object templates
* Bounds are set to `None` when unspecified instead of to that of the attribute template