### PR TITLE
Update objects to require names for all objects

### DIFF
--- a/gemd/demo/measurement_example.py
+++ b/gemd/demo/measurement_example.py
@@ -46,6 +46,7 @@ def make_flexural_test_measurement(my_id, deflection, extra_tags=frozenset()):
     modulus = stress / strain
 
     measurement = MeasurementRun(
+        name="3 Point Bend",
         uids={"my_id": my_id},
         tags=["3_pt_bend", "mechanical", "flex"] + list(extra_tags),
         properties=[

--- a/gemd/demo/tests/test_cake.py
+++ b/gemd/demo/tests/test_cake.py
@@ -164,4 +164,3 @@ def test_scope():
 
     assert any('template' in x for x in default_cake.spec.template.uids)
     assert not any('template' in x for x in third_cake.spec.template.uids)
-

--- a/gemd/demo/tests/test_cake.py
+++ b/gemd/demo/tests/test_cake.py
@@ -117,3 +117,7 @@ def test_cake():
 def test_import():
     """Make sure picture import runs."""
     import_toothpick_picture()
+
+
+if __name__ == "__main__":
+    test_cake()

--- a/gemd/entity/attribute/base_attribute.py
+++ b/gemd/entity/attribute/base_attribute.py
@@ -31,10 +31,8 @@ class BaseAttribute(DictSerializable):
 
     """
 
-    def __init__(self, name=None, template=None, origin="unknown", value=None, notes=None,
+    def __init__(self, name, *, template=None, origin="unknown", value=None, notes=None,
                  file_links=None):
-        if name is None:
-            raise ValueError("Attributes must be named")
         self.name = name
         self.notes = notes
 

--- a/gemd/entity/attribute/tests/test_base_attribute.py
+++ b/gemd/entity/attribute/tests/test_base_attribute.py
@@ -8,7 +8,7 @@ from gemd.entity.value.nominal_real import NominalReal
 
 def test_invalid_assignment():
     """Test that invalid assignments throw the appropriate errors."""
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         Property(value=NominalReal(10, ''))
     with pytest.raises(TypeError):
         Property(name="property", value=10)

--- a/gemd/entity/dict_serializable.py
+++ b/gemd/entity/dict_serializable.py
@@ -32,6 +32,7 @@ class DictSerializable(ABC):
 
         """
         expected_arg_names = inspect.getfullargspec(cls.__init__).args
+        expected_arg_names += inspect.getfullargspec(cls.__init__).kwonlyargs
         kwargs = {}
         for name, arg in d.items():
             if name in expected_arg_names:

--- a/gemd/entity/object/base_object.py
+++ b/gemd/entity/object/base_object.py
@@ -11,8 +11,8 @@ class BaseObject(BaseEntity):
 
     Parameters
     ----------
-    name: str, optional
-        Name of the material spec.
+    name: str, required
+        Name of the object.
     uids: Map[str, str], optional
         A collection of
         `unique IDs <https://citrineinformatics.github.io/gemd-documentation/
@@ -22,13 +22,13 @@ class BaseObject(BaseEntity):
         are hierarchical strings that store information about an entity. They can be used
         for filtering and discoverability.
     notes: str, optional
-        Long-form notes about the material spec.
+        Long-form notes about the object.
     file_links: List[FileLink], optional
         Links to associated files, with resource paths into the files API.
 
     """
 
-    def __init__(self, name=None, uids=None, tags=None, notes=None, file_links=None):
+    def __init__(self, name, *, uids=None, tags=None, notes=None, file_links=None):
         BaseEntity.__init__(self, uids, tags)
         self.notes = notes
         self._name = None

--- a/gemd/entity/object/has_quantities.py
+++ b/gemd/entity/object/has_quantities.py
@@ -8,7 +8,8 @@ fraction_bounds = RealBounds(lower_bound=0.0, upper_bound=1.0, default_units='')
 class HasQuantities(object):
     """Mixin-trait that includes the mass, volume, number fraction, and absolute quantity."""
 
-    def __init__(self, mass_fraction=None, volume_fraction=None, number_fraction=None,
+    def __init__(self, *,
+                 mass_fraction=None, volume_fraction=None, number_fraction=None,
                  absolute_quantity=None):
 
         self._mass_fraction = None

--- a/gemd/entity/object/ingredient_run.py
+++ b/gemd/entity/object/ingredient_run.py
@@ -50,7 +50,7 @@ class IngredientRun(BaseObject, HasQuantities):
 
     typ = "ingredient_run"
 
-    def __init__(self, material=None, process=None, mass_fraction=None,
+    def __init__(self, *, material=None, process=None, mass_fraction=None,
                  volume_fraction=None, number_fraction=None, absolute_quantity=None,
                  spec=None, uids=None, tags=None, notes=None, file_links=None):
         BaseObject.__init__(self, name=None, uids=uids, tags=tags,
@@ -77,7 +77,7 @@ class IngredientRun(BaseObject, HasQuantities):
     def name(self, name):
         # This messiness is a consequence of name being an inherited attribute
         if name is not None:
-            warnings.warn("Labels are set implicitly by associating with an "
+            warnings.warn("Name is set implicitly by associating with an "
                           "IngredientSpec; this value will likely be overwritten",
                           DeprecationWarning)
         self.__class__._name_setter(self, name)
@@ -93,7 +93,7 @@ class IngredientRun(BaseObject, HasQuantities):
         return self._labels
 
     @labels.setter
-    @deprecation.deprecated(deprecated_in="0.10", removed_in="0.11",
+    @deprecation.deprecated(deprecated_in="0.12", removed_in="0.13",
                             details="Labels are set implicitly by associating with an "
                                     "IngredientSpec")
     def labels(self, labels):

--- a/gemd/entity/object/ingredient_run.py
+++ b/gemd/entity/object/ingredient_run.py
@@ -139,7 +139,13 @@ class IngredientRun(BaseObject, HasQuantities):
 
     @classmethod
     def from_dict(cls, d):
-        """Suppresses name/label warnings during deserializaton."""
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=DeprecationWarning)
-            return super().from_dict(d)
+        # Overload from_dict because we may get name/labels from an independent
+        # resource, but not get the associated IngredientSpec
+        name = d.pop("name", None)
+        labels = d.pop("labels", None)
+        obj = super().from_dict(d)
+        if name is not None:
+            obj._name = name
+        if labels is not None:
+            obj._labels = labels
+        return obj

--- a/gemd/entity/object/ingredient_run.py
+++ b/gemd/entity/object/ingredient_run.py
@@ -40,10 +40,6 @@ class IngredientRun(BaseObject, HasQuantities):
     absolute_quantity: :py:class:`ContinuousValue \
     <gemd.entity.value.continuous_value.ContinuousValue>`, optional
         The absolute quantity of the ingredient in the process.
-    name: str, optional
-        Label on the ingredient that is unique within the process that contains it.
-    labels: List[str], optional
-        Additional labels on the ingredient that must be unique.
     spec: IngredientSpec
         The specification of which this ingredient is a realization.
     file_links: List[FileLink], optional
@@ -53,22 +49,14 @@ class IngredientRun(BaseObject, HasQuantities):
 
     typ = "ingredient_run"
 
-    def __init__(self, material=None, process=None, name=None, labels=None,
-                 mass_fraction=None, volume_fraction=None, number_fraction=None,
-                 absolute_quantity=None,
+    def __init__(self, material=None, process=None, mass_fraction=None,
+                 volume_fraction=None, number_fraction=None, absolute_quantity=None,
                  spec=None, uids=None, tags=None, notes=None, file_links=None):
-        BaseObject.__init__(self, name=name, uids=uids, tags=tags,
+        BaseObject.__init__(self, name=None, uids=uids, tags=tags,
                             notes=notes, file_links=file_links)
-        HasQuantities.__init__(self, mass_fraction, volume_fraction, number_fraction,
-                               absolute_quantity)
-        if name is not None:
-            warnings.warn("The 'name' argument for ingredient runs is deprecated. "
-                          "It may be overwritten by the name of this object's spec.",
-                          DeprecationWarning)
-        if labels is not None:
-            warnings.warn("The 'labels' argument for ingredient runs is deprecated. "
-                          "It may be overwritten by the labels of this object's spec.",
-                          DeprecationWarning)
+        HasQuantities.__init__(self, mass_fraction=mass_fraction, volume_fraction=volume_fraction,
+                               number_fraction=number_fraction, absolute_quantity=absolute_quantity
+                               )
         self._material = None
         self._process = None
         self._spec = None
@@ -76,8 +64,7 @@ class IngredientRun(BaseObject, HasQuantities):
 
         self.material = material
         self.process = process
-        self.labels = labels
-        # this may overwrite name/labels
+        # this will overwrite name/labels if/when they are set
         self.spec = spec
 
     @property

--- a/gemd/entity/object/ingredient_spec.py
+++ b/gemd/entity/object/ingredient_spec.py
@@ -12,6 +12,8 @@ class IngredientSpec(BaseObject, HasQuantities):
 
     Parameters
     ----------
+    name: str, required
+        Label on the ingredient that is unique within the process that contains it.
     uids: Map[str, str], optional
         A collection of
         `unique IDs <https://citrineinformatics.github.io/gemd-documentation/
@@ -38,8 +40,6 @@ class IngredientSpec(BaseObject, HasQuantities):
     absolute_quantity: :py:class:`ContinuousValue \
     <gemd.entity.value.continuous_value.ContinuousValue>`, optional
         The absolute quantity of the ingredient in the process.
-    name: str, optional
-        Label on the ingredient that is unique within the process that contains it.
     labels: List[str], optional
         Additional labels on the ingredient that must be unique.
     file_links: List[FileLink], optional
@@ -49,7 +49,7 @@ class IngredientSpec(BaseObject, HasQuantities):
 
     typ = "ingredient_spec"
 
-    def __init__(self, material=None, process=None, name=None, labels=None,
+    def __init__(self, name, *, material=None, process=None, labels=None,
                  mass_fraction=None, volume_fraction=None, number_fraction=None,
                  absolute_quantity=None,
                  uids=None, tags=None, notes=None, file_links=None):
@@ -57,18 +57,20 @@ class IngredientSpec(BaseObject, HasQuantities):
         Create an IngredientSpec object.
 
         Assigns a unique_label and other descriptive labels to a material used as an ingredient
+        :param name: of the ingredient as used in the process, i.e. "the peanut butter"
         :param material: MaterialSpec that is being used as the ingredient
         :param process: ProcessSpec that uses this ingredient
-        :param name: of the ingredient as used in the process, i.e. "the peanut butter"
         :param labels: that this ingredient belongs to, e.g. "spread" or "solvent"
         :param mass_fraction: fraction of the ingredients that is this input ingredient, by mass
         :param volume_fraction: fraction of the ingredients that is this ingredient, by volume
         :param number_fraction: fraction of the ingredients that is this ingredient, by number
         :param absolute_quantity: quantity of this ingredient in an absolute sense, e.g. 2 cups
         """
-        BaseObject.__init__(self, name, uids, tags, notes=notes, file_links=file_links)
-        HasQuantities.__init__(self, mass_fraction, volume_fraction, number_fraction,
-                               absolute_quantity)
+        BaseObject.__init__(self, name=name,
+                            uids=uids, tags=tags, notes=notes, file_links=file_links)
+        HasQuantities.__init__(self, mass_fraction=mass_fraction, volume_fraction=volume_fraction,
+                               number_fraction=number_fraction, absolute_quantity=absolute_quantity
+                               )
 
         self._material = None
         self._process = None

--- a/gemd/entity/object/material_run.py
+++ b/gemd/entity/object/material_run.py
@@ -10,7 +10,7 @@ class MaterialRun(BaseObject):
 
     Parameters
     ----------
-    name: str, optional
+    name: str, required
         Name of the material run.
     uids: Map[str, str], optional
         A collection of
@@ -44,7 +44,7 @@ class MaterialRun(BaseObject):
 
     skip = {"_measurements"}
 
-    def __init__(self, name=None, spec=None, process=None, sample_type="unknown",
+    def __init__(self, name, *, spec=None, process=None, sample_type="unknown",
                  uids=None, tags=None, notes=None, file_links=None):
         BaseObject.__init__(self, name=name, uids=uids, tags=tags, notes=notes,
                             file_links=file_links)

--- a/gemd/entity/object/material_spec.py
+++ b/gemd/entity/object/material_spec.py
@@ -12,7 +12,7 @@ class MaterialSpec(BaseObject, HasTemplate):
 
     Parameters
     ----------
-    name: str, optional
+    name: str, required
         Name of the material spec.
     uids: Map[str, str], optional
         A collection of
@@ -38,7 +38,7 @@ class MaterialSpec(BaseObject, HasTemplate):
 
     typ = "material_spec"
 
-    def __init__(self, name=None, template=None,
+    def __init__(self, name, *, template=None,
                  properties=None, process=None, uids=None, tags=None,
                  notes=None, file_links=None):
         BaseObject.__init__(self, name=name, uids=uids, tags=tags, notes=notes,

--- a/gemd/entity/object/measurement_run.py
+++ b/gemd/entity/object/measurement_run.py
@@ -16,7 +16,7 @@ class MeasurementRun(BaseObject, HasConditions, HasProperties, HasParameters, Ha
 
     Parameters
     ----------
-    name: str, optional
+    name: str, required
         Name of the measurement run.
     uids: Map[str, str], optional
         A collection of
@@ -49,7 +49,7 @@ class MeasurementRun(BaseObject, HasConditions, HasProperties, HasParameters, Ha
 
     typ = "measurement_run"
 
-    def __init__(self, name=None, spec=None, material=None,
+    def __init__(self, name, *, spec=None, material=None,
                  properties=None, conditions=None, parameters=None,
                  uids=None, tags=None, notes=None, file_links=None, source=None):
         BaseObject.__init__(self, name=name, uids=uids, tags=tags, notes=notes,

--- a/gemd/entity/object/measurement_spec.py
+++ b/gemd/entity/object/measurement_spec.py
@@ -13,7 +13,7 @@ class MeasurementSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
 
     Parameters
     ----------
-    name: str, optional
+    name: str, required
         Name of the measurement spec.
     uids: Map[str, str], optional
         A collection of
@@ -39,7 +39,7 @@ class MeasurementSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
 
     typ = "measurement_spec"
 
-    def __init__(self, name=None, template=None,
+    def __init__(self, name, *, template=None,
                  parameters=None, conditions=None,
                  uids=None, tags=None, notes=None, file_links=None):
         BaseObject.__init__(self, name=name, uids=uids, tags=tags, notes=notes,

--- a/gemd/entity/object/process_run.py
+++ b/gemd/entity/object/process_run.py
@@ -53,7 +53,7 @@ class ProcessRun(BaseObject, HasConditions, HasParameters, HasSource):
 
     skip = {"_output_material", "_ingredients"}
 
-    def __init__(self, name=None, spec=None,
+    def __init__(self, name, *, spec=None,
                  conditions=None, parameters=None,
                  uids=None, tags=None, notes=None, file_links=None, source=None):
         BaseObject.__init__(self, name=name, uids=uids, tags=tags, notes=notes,

--- a/gemd/entity/object/process_spec.py
+++ b/gemd/entity/object/process_spec.py
@@ -14,7 +14,7 @@ class ProcessSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
 
     Parameters
     ----------
-    name: str, optional
+    name: str, required
         Name of the process spec.
     uids: Map[str, str], optional
         A collection of
@@ -51,7 +51,7 @@ class ProcessSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
 
     skip = {"_output_material", "_ingredients"}
 
-    def __init__(self, name=None, template=None,
+    def __init__(self, name, *, template=None,
                  parameters=None, conditions=None,
                  uids=None, tags=None, notes=None, file_links=None):
         BaseObject.__init__(self, name=name, uids=uids, tags=tags, notes=notes,

--- a/gemd/entity/object/tests/test_ingredient_run.py
+++ b/gemd/entity/object/tests/test_ingredient_run.py
@@ -40,7 +40,7 @@ def test_invalid_assignment():
 
 
 def test_name_persistance():
-    """Verify that a serialized IngredientRun doesn't lose its name"""
+    """Verify that a serialized IngredientRun doesn't lose its name."""
     from gemd.entity.object import IngredientSpec
     from gemd.entity.link_by_uid import LinkByUID
     from gemd.json import GEMDJson

--- a/gemd/entity/object/tests/test_ingredient_run.py
+++ b/gemd/entity/object/tests/test_ingredient_run.py
@@ -55,9 +55,13 @@ def test_name_persistance():
                           process=ps_link, material=ms_link)
     run = IngredientRun(spec=spec,
                         process=pr_link, material=mr_link)
+    assert run.name == spec.name
+    assert run.labels == spec.labels
     run.spec = LinkByUID(scope='local', id='ing_spec')
     # Name and labels are now stashed but not stored
     assert run == je.copy(run)
+    assert run.name == spec.name
+    assert run.labels == spec.labels
 
 
 @pytest.mark.filterwarnings("ignore:Name is set implicitly")

--- a/gemd/entity/object/tests/test_ingredient_run.py
+++ b/gemd/entity/object/tests/test_ingredient_run.py
@@ -60,6 +60,9 @@ def test_name_persistance():
     assert run == je.copy(run)
 
 
+@pytest.mark.filterwarnings("ignore:Name is set implicitly")
+@pytest.mark.filterwarnings("ignore:Labels are set implicitly")
+@pytest.mark.filterwarnings("ignore:labels is deprecated")
 def test_deprecated():
     """These are tests that will be obsolete but are required for 100 %."""
     name = 'name'

--- a/gemd/entity/object/tests/test_ingredient_run.py
+++ b/gemd/entity/object/tests/test_ingredient_run.py
@@ -37,3 +37,24 @@ def test_invalid_assignment():
         IngredientRun(spec=5)
     with pytest.raises(TypeError):
         IngredientRun(name="Flour")  # IngredientRuns don't have their own name
+
+
+def test_name_persistance():
+    """Verify that a serialized IngredientRun doesn't lose its name"""
+    from gemd.entity.object import IngredientSpec
+    from gemd.entity.link_by_uid import LinkByUID
+    from gemd.json import GEMDJson
+
+    je = GEMDJson()
+
+    ms_link = LinkByUID(scope='local', id='mat_spec')
+    mr_link = LinkByUID(scope='local', id='mat_run')
+    ps_link = LinkByUID(scope='local', id='pro_spec')
+    pr_link = LinkByUID(scope='local', id='pro_run')
+    spec = IngredientSpec(name='Ingred', labels=['some', 'words'],
+                          process=ps_link, material=ms_link)
+    run = IngredientRun(spec=spec,
+                        process=pr_link, material=mr_link)
+    run.spec = LinkByUID(scope='local', id='ing_spec')
+    # Name and labels are now stashed but not stored
+    assert run == je.copy(run)

--- a/gemd/entity/object/tests/test_ingredient_run.py
+++ b/gemd/entity/object/tests/test_ingredient_run.py
@@ -58,3 +58,19 @@ def test_name_persistance():
     run.spec = LinkByUID(scope='local', id='ing_spec')
     # Name and labels are now stashed but not stored
     assert run == je.copy(run)
+
+
+def test_deprecated():
+    """These are tests that will be obsolete but are required for 100 %."""
+    name = 'name'
+    labels = ['label', 'also']
+    with pytest.raises(TypeError):
+        IngredientRun(name=name)
+    with pytest.raises(TypeError):
+        IngredientRun(labels=labels)
+
+    run = IngredientRun()
+    run.name = name
+    run.labels = labels
+    assert run.name == name
+    assert run.labels == labels

--- a/gemd/entity/object/tests/test_ingredient_run.py
+++ b/gemd/entity/object/tests/test_ingredient_run.py
@@ -35,3 +35,5 @@ def test_invalid_assignment():
         IngredientRun(process="process")
     with pytest.raises(TypeError):
         IngredientRun(spec=5)
+    with pytest.raises(TypeError):
+        IngredientRun(name="Flour")  # IngredientRuns don't have their own name

--- a/gemd/entity/object/tests/test_ingredient_spec.py
+++ b/gemd/entity/object/tests/test_ingredient_spec.py
@@ -84,3 +84,5 @@ def test_invalid_assignment():
         IngredientSpec(name="name", material=NominalReal(3, ''))
     with pytest.raises(TypeError):
         IngredientSpec(name="name", process="process")
+    with pytest.raises(TypeError):
+        IngredientSpec()  # Name is required

--- a/gemd/entity/object/tests/test_material_run.py
+++ b/gemd/entity/object/tests/test_material_run.py
@@ -96,6 +96,8 @@ def test_invalid_assignment():
         MaterialRun("name", spec=ProcessRun("a process"))
     with pytest.raises(TypeError):
         MaterialRun("name", process=MaterialSpec("a spec"))
+    with pytest.raises(TypeError):
+        MaterialRun()  # Name is required
 
 
 def test_template_access():

--- a/gemd/entity/object/tests/test_material_run.py
+++ b/gemd/entity/object/tests/test_material_run.py
@@ -39,8 +39,8 @@ def test_material_run():
 
     # Create a MaterialRun, and make sure an inappropriate value for sample_type throws ValueError
     with pytest.raises(ValueError):
-        mat = MaterialRun(spec=mat_spec, sample_type="imaginary")
-    mat = MaterialRun(spec=mat_spec, sample_type="virtual")
+        mat = MaterialRun("name", spec=mat_spec, sample_type="imaginary")
+    mat = MaterialRun("name", spec=mat_spec, sample_type="virtual")
 
     # ensure that serialization does not change the MaterialRun
     copy = loads(dumps(mat))

--- a/gemd/entity/object/tests/test_material_spec.py
+++ b/gemd/entity/object/tests/test_material_spec.py
@@ -26,3 +26,5 @@ def test_invalid_assignment():
         MaterialSpec("name", process=["Process 1", "Process 2"])
     with pytest.raises(TypeError):
         MaterialSpec("name", template=MaterialSpec("another spec"))
+    with pytest.raises(TypeError):
+        MaterialSpec()  # Name is required

--- a/gemd/entity/object/tests/test_measurement_run.py
+++ b/gemd/entity/object/tests/test_measurement_run.py
@@ -27,7 +27,7 @@ def test_measurement_spec():
     )
 
     # Create a measurement run from this measurement spec
-    measurement = MeasurementRun(conditions=condition, spec=spec)
+    measurement = MeasurementRun("The Measurement", conditions=condition, spec=spec)
 
     copy = loads(dumps(measurement))
     assert dumps(copy.spec) == dumps(measurement.spec), \
@@ -41,7 +41,7 @@ def test_material_soft_link():
 
     # The .measurements member should not be settable
     with pytest.raises(AttributeError):
-        dye.measurements = [MeasurementRun()]
+        dye.measurements = [MeasurementRun("Dummy")]
 
     absorbance = MeasurementRun(
         name="Absorbance",
@@ -80,7 +80,7 @@ def test_material_soft_link():
 def test_material_id_link():
     """Check that a measurement can be linked to a material that is a LinkByUID."""
     mat = LinkByUID('id', str(uuid4()))
-    meas = MeasurementRun(material=mat)
+    meas = MeasurementRun("name", material=mat)
     assert meas.material == mat
     assert loads(dumps(meas)) == meas
 

--- a/gemd/entity/object/tests/test_measurement_run.py
+++ b/gemd/entity/object/tests/test_measurement_run.py
@@ -121,6 +121,8 @@ def test_invalid_assignment():
         MeasurementRun("name", spec=Condition("value of pi", value=NominalReal(3.14159, '')))
     with pytest.raises(TypeError):
         MeasurementRun("name", material=FileLink("filename", "url"))
+    with pytest.raises(TypeError):
+        MeasurementRun()  # Name is required
 
 
 def test_template_access():

--- a/gemd/entity/object/tests/test_process_run.py
+++ b/gemd/entity/object/tests/test_process_run.py
@@ -16,11 +16,11 @@ def test_process_spec():
     """Tests that the Process Spec/Run connection persists when serializing."""
     # Create the ProcessSpec
     condition1 = Condition(name="a condition on the process in general")
-    spec = ProcessSpec(conditions=condition1)
+    spec = ProcessSpec("Spec", conditions=condition1)
 
     # Create the ProcessRun with a link to the ProcessSpec from above
     condition2 = Condition(name="a condition on this process run in particular")
-    process = ProcessRun(conditions=condition2, spec=spec)
+    process = ProcessRun("Run", conditions=condition2, spec=spec)
 
     copy_process = loads(dumps(process))
     assert dumps(copy_process.spec) == dumps(spec), \

--- a/gemd/entity/object/tests/test_process_run.py
+++ b/gemd/entity/object/tests/test_process_run.py
@@ -46,6 +46,8 @@ def test_invalid_assignment():
     """Invalid assignments to `spec` throw a TypeError."""
     with pytest.raises(TypeError):
         ProcessRun("name", spec=[ProcessSpec("spec")])
+    with pytest.raises(TypeError):
+        ProcessRun()  # Name is required
 
 
 def test_template_access():

--- a/gemd/entity/object/tests/test_process_spec.py
+++ b/gemd/entity/object/tests/test_process_spec.py
@@ -57,3 +57,9 @@ def test_ingredient_spec():
     proc_spec_copy = loads(dumps(proc_spec))
 
     assert proc_spec_copy == proc_spec, "Full structure wasn't preserved across serialization"
+
+
+def test_invalid_assignment():
+    """Omitting a name throws a TypeError."""
+    with pytest.raises(TypeError):
+        ProcessSpec()  # Name is required

--- a/gemd/entity/template/attribute_template.py
+++ b/gemd/entity/template/attribute_template.py
@@ -9,7 +9,7 @@ class AttributeTemplate(BaseEntity):
 
     Parameters
     ----------
-    name: str
+    name: str, required
         The name of the attribute template.
     bounds: :py:class:`BaseBounds <gemd.entity.bounds.base_bounds.BaseBounds>`
         Bounds circumscribe the values that are valid according to this attribute template.
@@ -26,7 +26,7 @@ class AttributeTemplate(BaseEntity):
 
     """
 
-    def __init__(self, name=None, description=None, bounds=None, uids=None, tags=None):
+    def __init__(self, name, *, description=None, bounds=None, uids=None, tags=None):
         BaseEntity.__init__(self, uids, tags)
         self.name = name
         self.description = description

--- a/gemd/entity/template/base_template.py
+++ b/gemd/entity/template/base_template.py
@@ -11,7 +11,7 @@ class BaseTemplate(BaseEntity):
 
     Parameters
     ----------
-    name: str, optional
+    name: str, required
         The name of the object template.
     description: str, optional
         Long-form description of the object template.
@@ -26,7 +26,7 @@ class BaseTemplate(BaseEntity):
 
     """
 
-    def __init__(self, name=None, description=None, uids=None, tags=None):
+    def __init__(self, name, *, description=None, uids=None, tags=None):
         BaseEntity.__init__(self, uids, tags)
         self.name = name
         self.description = description

--- a/gemd/entity/template/material_template.py
+++ b/gemd/entity/template/material_template.py
@@ -13,7 +13,7 @@ class MaterialTemplate(BaseTemplate, HasPropertyTemplates):
 
     Parameters
     ----------
-    name: str, optional
+    name: str, required
         The name of the material template.
     description: str, optional
         Long-form description of the material template.
@@ -37,6 +37,10 @@ class MaterialTemplate(BaseTemplate, HasPropertyTemplates):
 
     typ = "material_template"
 
-    def __init__(self, name=None, description=None, properties=None, uids=None, tags=None):
-        BaseTemplate.__init__(self, name, description, uids, tags)
+    def __init__(self, name, *, description=None,
+                 properties=None,
+                 uids=None, tags=None):
+        BaseTemplate.__init__(self, name=name, description=description,
+                              uids=uids, tags=tags
+                              )
         HasPropertyTemplates.__init__(self, properties)

--- a/gemd/entity/template/measurement_template.py
+++ b/gemd/entity/template/measurement_template.py
@@ -16,7 +16,7 @@ class MeasurementTemplate(BaseTemplate,
 
     Parameters
     ----------
-    name: str, optional
+    name: str, required
         The name of the measurement template.
     description: str, optional
         Long-form description of the measurement template.
@@ -54,11 +54,11 @@ class MeasurementTemplate(BaseTemplate,
 
     typ = "measurement_template"
 
-    def __init__(self,
-                 name=None, description=None,
+    def __init__(self, name, *, description=None,
                  properties=None, conditions=None, parameters=None,
                  uids=None, tags=None):
-        BaseTemplate.__init__(self, name, description, uids, tags)
+        BaseTemplate.__init__(self, name=name, description=description,
+                              uids=uids, tags=tags)
         HasPropertyTemplates.__init__(self, properties)
         HasConditionTemplates.__init__(self, conditions)
         HasParameterTemplates.__init__(self, parameters)

--- a/gemd/entity/template/process_template.py
+++ b/gemd/entity/template/process_template.py
@@ -15,7 +15,7 @@ class ProcessTemplate(BaseTemplate, HasConditionTemplates, HasParameterTemplates
 
     Parameters
     ----------
-    name: str, optional
+    name: str, required
         The name of the process template.
     description: str, optional
         Long-form description of the process template.
@@ -46,11 +46,12 @@ class ProcessTemplate(BaseTemplate, HasConditionTemplates, HasParameterTemplates
 
     typ = "process_template"
 
-    def __init__(self, name=None, description=None,
+    def __init__(self, name, *, description=None,
                  conditions=None, parameters=None,
                  allowed_names=None, allowed_labels=None,
                  uids=None, tags=None):
-        BaseTemplate.__init__(self, name, description, uids, tags)
+        BaseTemplate.__init__(self, name=name, description=description,
+                              uids=uids, tags=tags)
         HasConditionTemplates.__init__(self, conditions)
         HasParameterTemplates.__init__(self, parameters)
 

--- a/gemd/entity/tests/test_util.py
+++ b/gemd/entity/tests/test_util.py
@@ -20,7 +20,7 @@ from gemd.entity.value.uniform_real import UniformReal
 
 def test_make_instance():
     """Build up several linked objects and test their properties."""
-    msr_spec = MeasurementSpec()
+    msr_spec = MeasurementSpec("Measurement")
     assert isinstance(make_instance(msr_spec), MeasurementRun)
 
     mat_spec = MaterialSpec(name='Mat name')

--- a/gemd/ingest/material_run_example.py
+++ b/gemd/ingest/material_run_example.py
@@ -81,7 +81,7 @@ def ingest_material_run(data, material_spec=None, process_run=None):
     if not isinstance(data, dict):
         raise ValueError("This ingester operates on dict, but got {}".format(type(data)))
 
-    material = MaterialRun()
+    material = MaterialRun("Material Run")
 
     sample_id = data.get("sample_id")
     if sample_id:
@@ -92,7 +92,7 @@ def ingest_material_run(data, material_spec=None, process_run=None):
         material.tags = tags
 
     for experiment in data.get("experiments", []):
-        measurement = MeasurementRun()
+        measurement = MeasurementRun("Measurement Run")
 
         for name in set(known_properties.keys()).intersection(experiment.keys()):
             prop = Property(

--- a/gemd/ingest/table_example.py
+++ b/gemd/ingest/table_example.py
@@ -11,7 +11,7 @@ known_conditions = ["temperature"]
 def ingest_table(material_run, table):
     """Ingest a material run into an existing table."""
     for _, row in table.iterrows():
-        exp = MeasurementRun()
+        exp = MeasurementRun("Material Run")
         for prop_name in known_properties:
             if prop_name in row:
                 exp.properties.append(Property(name=prop_name,

--- a/gemd/ingest/tests/test_table_example.py
+++ b/gemd/ingest/tests/test_table_example.py
@@ -14,7 +14,7 @@ data = [
 
 def test_table():
     """Convert a dictionary to a pandas dataframe and then to a table."""
-    material = MaterialRun()
+    material = MaterialRun("name")
     df = pd.DataFrame.from_records(data)
     result = ingest_table(material, df)
     assert isinstance(result, MaterialRun)

--- a/gemd/json/tests/test_json.py
+++ b/gemd/json/tests/test_json.py
@@ -28,11 +28,11 @@ def test_serialize():
     """Serializing a nested object should be identical to individually serializing each piece."""
     condition = Condition(name="A condition", value=NominalReal(7, ''))
     parameter = Parameter(name="A parameter", value=NormalReal(mean=17, std=1, units=''))
-    input_material = MaterialRun(tags="input")
-    process = ProcessRun(tags="A tag on a process run")
+    input_material = MaterialRun("name", tags="input")
+    process = ProcessRun("name", tags="A tag on a process run")
     ingredient = IngredientRun(material=input_material, process=process)
-    material = MaterialRun(tags=["A tag on a material"], process=process)
-    measurement = MeasurementRun(tags="A tag on a measurement", conditions=condition,
+    material = MaterialRun("name", tags=["A tag on a material"], process=process)
+    measurement = MeasurementRun("name", tags="A tag on a measurement", conditions=condition,
                                  parameters=parameter, material=material)
 
     # serialize the root of the tree
@@ -52,7 +52,7 @@ def test_deserialize():
     """Round-trip serde should leave the object unchanged."""
     condition = Condition(name="A condition", value=NominalReal(7, ''))
     parameter = Parameter(name="A parameter", value=NormalReal(mean=17, std=1, units=''))
-    measurement = MeasurementRun(tags="A tag on a measurement", conditions=condition,
+    measurement = MeasurementRun("name", tags="A tag on a measurement", conditions=condition,
                                  parameters=parameter)
     copy_meas = GEMDJson().copy(measurement)
     assert(copy_meas.conditions[0].value == measurement.conditions[0].value)
@@ -62,10 +62,10 @@ def test_deserialize():
 
 def test_scope_control():
     """Serializing a nested object should be identical to individually serializing each piece."""
-    input_material = MaterialSpec()
-    process = ProcessSpec()
-    IngredientSpec(material=input_material, process=process)
-    material = MaterialSpec(process=process)
+    input_material = MaterialSpec("input_material")
+    process = ProcessSpec("process")
+    IngredientSpec("ingredient", material=input_material, process=process)
+    material = MaterialSpec("name", process=process)
 
     # Verify the default scope is there
     default_json = GEMDJson()
@@ -466,6 +466,7 @@ def test_deeply_nested_rehydration():
     },
     {
       "type": "ingredient_spec",
+      "name": "Shortening",
       "material": {
         "type": "link_by_uid",
         "scope": "id",
@@ -485,6 +486,7 @@ def test_deeply_nested_rehydration():
     },
     {
       "type": "ingredient_spec",
+      "name": "Flour",
       "material": {
         "type": "link_by_uid",
         "scope": "id",

--- a/gemd/tests/test_examples.py
+++ b/gemd/tests/test_examples.py
@@ -101,7 +101,7 @@ def make_data_island(density, bulk_modulus, firing_temperature, binders, powders
         spec=firing_spec
     )
     IngredientRun(
-        green_sample,
+        material=green_sample,
         process=firing_process,
         mass_fraction=NormalReal(1.0, 0.0, ''),
         volume_fraction=NormalReal(1.0, 0.0, ''),

--- a/gemd/util/tests/test_foreach.py
+++ b/gemd/util/tests/test_foreach.py
@@ -11,7 +11,7 @@ def test_recursive_foreach():
     mat_run = MaterialRun("foo")
     process_run = ProcessRun("bar")
     IngredientRun(process=process_run, material=mat_run)
-    output = MaterialRun(process=process_run)
+    output = MaterialRun("material", process=process_run)
 
     # property templates are trickier than templates because they are referenced in attributes
     template = PropertyTemplate("prop", bounds=RealBounds(0, 1, ""))

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='gemd',
-      version='0.10.0',
+      version='0.12.0',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='gemd',
-      version='0.9.1',
+      version='0.10.0',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',


### PR DESCRIPTION
This PR modifies constructors for all GEMD entities to require a name value and only accepts name as a positional argument.  

The exception to this is IngredientRun, which explicitly removes `name` and `labels` from its argument list since those are not set by users.