### PR TITLE
Include root object in flatten outputs

### DIFF
--- a/gemd/util/impl.py
+++ b/gemd/util/impl.py
@@ -128,9 +128,6 @@ def flatten(obj, scope):
 
     # list of uids that we've seen, to avoid returning duplicates
     known_uids = set()
-    # if isinstance(obj, BaseEntity):
-    #     for uid in obj.uids.items():
-    #         known_uids.add(uid)
 
     def _flatten(base_obj):
         nonlocal known_uids

--- a/gemd/util/impl.py
+++ b/gemd/util/impl.py
@@ -128,11 +128,12 @@ def flatten(obj, scope):
 
     # list of uids that we've seen, to avoid returning duplicates
     known_uids = set()
-    if isinstance(obj, BaseEntity):
-        for uid in obj.uids.items():
-            known_uids.add(uid)
+    # if isinstance(obj, BaseEntity):
+    #     for uid in obj.uids.items():
+    #         known_uids.add(uid)
 
     def _flatten(base_obj):
+        nonlocal known_uids
         to_return = []
         # get all the uids of this object
         uids = list(base_obj.uids.items())

--- a/gemd/util/tests/test_flatten.py
+++ b/gemd/util/tests/test_flatten.py
@@ -51,7 +51,3 @@ def test_flatmap_unidirectional_ordering():
 
     assert len(recursive_flatmap(proc, lambda x: [x], unidirectional=False)) == 2
     assert len(recursive_flatmap(proc, lambda x: [x], unidirectional=True)) == 0
-
-
-if __name__ == '__main__':
-    test_flatten_empty_history()

--- a/gemd/util/tests/test_flatten.py
+++ b/gemd/util/tests/test_flatten.py
@@ -31,16 +31,16 @@ def test_flatten_empty_history():
     transform_run = ProcessRun(name="transformed", spec=transform)
     ingredient_run = IngredientRun(material=input_run, process=transform_run, spec=ingredient)
 
-    assert len(flatten(procured, 'test-scope')) == 1
+    assert len(flatten(procured, 'test-scope')) == 2
     assert 'test-scope' in procured.uids
-    assert len(flatten(input, 'test-scope')) == 1
-    assert len(flatten(ingredient, 'test-scope')) == 3
-    assert len(flatten(transform, 'test-scope')) == 3
+    assert len(flatten(input, 'test-scope')) == 2
+    assert len(flatten(ingredient, 'test-scope')) == 4
+    assert len(flatten(transform, 'test-scope')) == 4
 
-    assert len(flatten(procured_run, 'test-scope')) == 3
-    assert len(flatten(input_run, 'test-scope')) == 3
-    assert len(flatten(ingredient_run, 'test-scope')) == 7
-    assert len(flatten(transform_run, 'test-scope')) == 7
+    assert len(flatten(procured_run, 'test-scope')) == 4
+    assert len(flatten(input_run, 'test-scope')) == 4
+    assert len(flatten(ingredient_run, 'test-scope')) == 8
+    assert len(flatten(transform_run, 'test-scope')) == 8
 
 
 def test_flatmap_unidirectional_ordering():
@@ -51,3 +51,7 @@ def test_flatmap_unidirectional_ordering():
 
     assert len(recursive_flatmap(proc, lambda x: [x], unidirectional=False)) == 2
     assert len(recursive_flatmap(proc, lambda x: [x], unidirectional=True)) == 0
+
+
+if __name__ == '__main__':
+    test_flatten_empty_history()

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='gemd',
-      version='0.9.3',
+      version='0.10.0',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='gemd',
-      version='0.9.2',
+      version='0.9.3',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',


### PR DESCRIPTION
Modified behavior of `flatten` to include the root object in the returned list when that object is a Base Entity.  Previously, that result required wrapping the root object in an array or equivalent.  I have verified that this change does not break any of our existing end-to-end tests or downstream libraries.

In theory this change could break code, so I am incrementing minor version.