### PR TITLE
Rework cake data example

### DIFF
--- a/gemd/demo/cake.py
+++ b/gemd/demo/cake.py
@@ -122,6 +122,10 @@ def make_cake_templates():
     )
 
     # Objects
+    tmpl["Procuring"] = ProcessTemplate(
+        name="Procuring",
+        description="Buyin' stuff"
+    )
     tmpl["Baking"] = ProcessTemplate(
         name="Baking",
         description='Using heat to promote chemical reactions in a material',
@@ -129,38 +133,19 @@ def make_cake_templates():
         conditions=[(tmpl["Oven temperature"], RealBounds(0, 700, "degF"))],
         parameters=[(tmpl["Oven temperature setting"], RealBounds(100, 550, "degF"))]
     )
-
-    tmpl["Doneness"] = MeasurementTemplate(
-        name="Doneness test",
-        description="An ensemble of tests to determine the doneness of a baked good",
-        properties=[tmpl["Toothpick test"], tmpl["Color"]]
+    tmpl["Icing"] = ProcessTemplate(
+        name="Icing",
+        description='Applying a coating to a substrate',
+        allowed_labels=['coating', 'substrate']
     )
-
-    tmpl["Taste test"] = MeasurementTemplate(
-        name="Taste test",
-        properties=[tmpl["Tastiness"]]
-    )
-
-    tmpl["Nutritional Analysis"] = MeasurementTemplate(
-        name="Nutritional Analysis",
-        properties=[tmpl["Nutritional Information"]],
-        conditions=[tmpl["Sample Mass"]],
-        parameters=[tmpl["Expected Sample Mass"]]
-    )
-    tmpl["Elemental Analysis"] = MeasurementTemplate(
-        name="Elemental Analysis",
-        properties=[tmpl["Chemical Formula"]],
-        conditions=[tmpl["Sample Mass"]],
-        parameters=[tmpl["Expected Sample Mass"]]
-    )
-
-    tmpl["Dessert"] = MaterialTemplate(
-        name="Dessert",
-        properties=[tmpl["Tastiness"]]
+    tmpl["Mixing"] = ProcessTemplate(
+        name="Mixing",
+        description='Physically combining ingredients',
+        allowed_labels=['wet', 'dry', 'leavening', 'seasoning',
+                        'sweetener', 'shortening', 'flavoring']
     )
 
     tmpl["Generic Material"] = MaterialTemplate(name="Generic")
-
     tmpl["Nutritional Material"] = MaterialTemplate(
         name="Nutritional Material",
         description="A material with FDA Nutrition Facts attached",
@@ -176,15 +161,32 @@ def make_cake_templates():
             tmpl["Molecular Structure"]
         ]
     )
-    tmpl["Icing"] = ProcessTemplate(name="Icing",
-                                    description='Applying a coating to a substrate',
-                                    allowed_labels=['coating', 'substrate'])
-    tmpl["Mixing"] = ProcessTemplate(name="Mixing",
-                                     description='Physically combining ingredients',
-                                     allowed_labels=['wet', 'dry', 'leavening', 'seasoning',
-                                                     'sweetener', 'shortening', 'flavoring'])
-    tmpl["Procuring"] = ProcessTemplate(name="Procuring",
-                                        description="Obtaining materials from a third party.")
+    tmpl["Dessert"] = MaterialTemplate(
+        name="Dessert",
+        properties=[tmpl["Tastiness"]]
+    )
+
+    tmpl["Doneness"] = MeasurementTemplate(
+        name="Doneness test",
+        description="An ensemble of tests to determine the doneness of a baked good",
+        properties=[tmpl["Toothpick test"], tmpl["Color"]]
+    )
+    tmpl["Taste test"] = MeasurementTemplate(
+        name="Taste test",
+        properties=[tmpl["Tastiness"]]
+    )
+    tmpl["Nutritional Analysis"] = MeasurementTemplate(
+        name="Nutritional Analysis",
+        properties=[tmpl["Nutritional Information"]],
+        conditions=[tmpl["Sample Mass"]],
+        parameters=[tmpl["Expected Sample Mass"]]
+    )
+    tmpl["Elemental Analysis"] = MeasurementTemplate(
+        name="Elemental Analysis",
+        properties=[tmpl["Chemical Formula"]],
+        conditions=[tmpl["Sample Mass"]],
+        parameters=[tmpl["Expected Sample Mass"]]
+    )
 
     for key in tmpl:
         tmpl[key].add_uid(DEMO_SCOPE + "-template", key)

--- a/gemd/demo/cake.py
+++ b/gemd/demo/cake.py
@@ -169,6 +169,10 @@ def make_cake_templates():
             tmpl["Molecular Structure"]
         ]
     )
+    tmpl["Baked Good"] = MaterialTemplate(
+        name="Baked Good",
+        properties=[tmpl["Toothpick test"], tmpl["Color"]]
+    )
     tmpl["Dessert"] = MaterialTemplate(
         name="Dessert",
         properties=[tmpl["Tastiness"]]
@@ -314,7 +318,24 @@ def make_cake_spec(tmpl=None):
                 "notes": 'Using heat to convert batter into a solid matrix'
             }
         ),
-        template=tmpl["Generic Material"],
+        template=tmpl["Baked Good"],
+        properties=[
+            PropertyAndConditions(
+                property=Property(
+                    name="Toothpick test",
+                    value=NominalCategorical("completely clean"),
+                    template=tmpl["Toothpick test"]
+                )
+            ),
+            PropertyAndConditions(
+                property=Property(
+                    name="Color",
+                    value=NominalCategorical("Golden brown"),
+                    template=tmpl["Color"],
+                    origin="specified"
+                )
+            )
+        ],
         tags=[
             'substrate'
         ],

--- a/gemd/demo/cake.py
+++ b/gemd/demo/cake.py
@@ -622,6 +622,7 @@ def make_cake_spec(tmpl=None):
                 "notes": 'Purchasing milk'
             }
         ),
+        template=tmpl["Generic Material"],
         tags=[
             'raw material',
             'produce',
@@ -653,6 +654,7 @@ def make_cake_spec(tmpl=None):
                 "notes": 'Purchasing chocolate'
             }
         ),
+        template=tmpl["Generic Material"],
         tags=[
             'raw material'
         ],
@@ -789,7 +791,7 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
 
     def find_name(name, material):
         # Recursively search for the right material
-        if name == material.name:
+        if name in material.name:
             return material
         for ingredient in material.process.ingredients:
             result = find_name(name, ingredient.material)
@@ -986,7 +988,18 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
     run_key = md5.hexdigest()
 
     # Crawl tree and annotate with uids; only add ids if there's nothing there
-    recursive_foreach(cake, lambda obj: obj.uids or obj.add_uid(DEMO_SCOPE, obj.name + run_key))
+    name_count = dict()
+
+    def _disambig(name):
+        nonlocal name_count
+        if name in name_count:
+            name_count[name] = name_count[name] + 1
+            return "{}-{}".format(name, name_count[name])
+        else:
+            name_count[name] = 1
+            return name
+
+    recursive_foreach(cake, lambda obj: obj.uids or obj.add_uid(DEMO_SCOPE, _disambig(obj.name) + run_key))
 
     cake.notes = cake.notes + "; Très délicieux! 😀"
     cake.file_links = [FileLink(

--- a/gemd/demo/cake.py
+++ b/gemd/demo/cake.py
@@ -302,6 +302,18 @@ def make_cake_spec(tmpl=None):
                 "tags": [
                     'oven::baking'
                 ],
+                "conditions": [
+                    Condition(name='Cooking time',
+                              template=tmpl['Cooking time'],
+                              origin=Origin.SPECIFIED,
+                              value=NormalReal(mean=50, std=5, units='min'))
+                ],
+                "parameters": [
+                    Parameter(name='Oven temperature setting',
+                              template=tmpl['Oven temperature setting'],
+                              origin="specified",
+                              value=NominalReal(nominal=350, units='degF'))
+                ],
                 "notes": 'Using heat to convert batter into a solid matrix'
             }
         ),
@@ -864,17 +876,10 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
                                               template=tmpl['Cooking time'],
                                               origin=Origin.MEASURED,
                                               value=NominalReal(nominal=48, units='min')))
-    baked.spec.process.conditions.append(Condition(name='Cooking time',
-                                                   template=tmpl['Cooking time'],
-                                                   origin=Origin.SPECIFIED,
-                                                   value=NormalReal(mean=50, std=5, units='min')))
     baked.process.conditions.append(Condition(name='Oven temperature',
                                               origin="measured",
                                               value=NominalReal(nominal=362, units='degF')))
-    baked.spec.process.parameters.append(Parameter(name='Oven temperature setting',
-                                                   template=tmpl['Oven temperature setting'],
-                                                   origin="specified",
-                                                   value=NominalReal(nominal=350, units='degF')))
+
     cake_taste.properties.append(Property(name='Tastiness',
                                           origin=Origin.MEASURED,
                                           template=tmpl['Tastiness'],

--- a/gemd/demo/cake.py
+++ b/gemd/demo/cake.py
@@ -233,13 +233,14 @@ def make_cake_spec(tmpl=None):
     if tmpl is None:
         tmpl = make_cake_templates()
 
-    def _ingredient_kwargs(material):
+    def _make_ingredient(material, **kwargs):
         """Convenience method to utilize material fields in creating an ingredient's arguments."""
-        return {
-            "name": material.name.lower(),
-            "tags": list(material.tags),
-            "material": material
-        }
+        return IngredientSpec(
+            name=material.name.lower(),
+            tags=list(material.tags),
+            material=material,
+            **kwargs
+        )
 
     def _material_kwargs(material_name, process_tmpl_name, process_kwargs):
         """Convenience method to reuse material name in creating a material's arguments."""
@@ -308,8 +309,8 @@ def make_cake_spec(tmpl=None):
         ],
         notes='Chocolate frosting'
     )
-    IngredientSpec(
-        **_ingredient_kwargs(frosting),
+    _make_ingredient(
+        material=frosting,
         notes='Seems like a lot of frosting',
         labels=['coating'],
         process=cake.process,
@@ -362,8 +363,8 @@ def make_cake_spec(tmpl=None):
         ],
         notes='The cakey part of the cake'
     )
-    IngredientSpec(
-        **_ingredient_kwargs(baked_cake),
+    _make_ingredient(
+        material=baked_cake,
         labels=['substrate'],
         process=cake.process
     )
@@ -392,8 +393,8 @@ def make_cake_spec(tmpl=None):
         ],
         notes='The fluid that converts to cake with heat'
     )
-    IngredientSpec(
-        **_ingredient_kwargs(batter),
+    _make_ingredient(
+        material=batter,
         labels=['precursor'],
         process=baked_cake.process
     )
@@ -422,8 +423,8 @@ def make_cake_spec(tmpl=None):
         ],
         notes='The wet fraction of a batter'
     )
-    IngredientSpec(
-        **_ingredient_kwargs(wetmix),
+    _make_ingredient(
+        material=wetmix,
         labels=['wet'],
         process=batter.process
     )
@@ -445,8 +446,8 @@ def make_cake_spec(tmpl=None):
         ],
         notes='The dry fraction of a batter'
     )
-    IngredientSpec(
-        **_ingredient_kwargs(drymix),
+    _make_ingredient(
+        material=drymix,
         labels=['dry'],
         process=batter.process,
         absolute_quantity=NominalReal(nominal=3.052, units='cups')
@@ -496,8 +497,8 @@ def make_cake_spec(tmpl=None):
         ],
         notes='All-purpose flour'
     )
-    IngredientSpec(
-        **_ingredient_kwargs(flour),
+    _make_ingredient(
+        material=flour,
         labels=['dry'],
         process=drymix.process,
         volume_fraction=NominalReal(nominal=0.9829, units='')  # 3 cups
@@ -522,8 +523,8 @@ def make_cake_spec(tmpl=None):
         ],
         notes='Leavening agent for cake'
     )
-    IngredientSpec(
-        **_ingredient_kwargs(baking_powder),
+    _make_ingredient(
+        material=baking_powder,
         labels=['leavening', 'dry'],
         process=drymix.process,
         volume_fraction=NominalReal(nominal=0.0137, units='')  # 2 teaspoons
@@ -551,8 +552,8 @@ def make_cake_spec(tmpl=None):
             PropertyAndConditions(Property(name='Formula', value=EmpiricalFormula("NaCl")))
         ]
     )
-    IngredientSpec(
-        **_ingredient_kwargs(salt),
+    _make_ingredient(
+        material=salt,
         labels=['dry', 'seasoning'],
         process=drymix.process,
         volume_fraction=NominalReal(nominal=0.0034, units='')  # 1/2 teaspoon
@@ -586,8 +587,8 @@ def make_cake_spec(tmpl=None):
             )
         ]
     )
-    IngredientSpec(
-        **_ingredient_kwargs(sugar),
+    _make_ingredient(
+        material=sugar,
         labels=['wet', 'sweetener'],
         process=wetmix.process,
         absolute_quantity=NominalReal(nominal=2, units='cups')
@@ -613,14 +614,14 @@ def make_cake_spec(tmpl=None):
         ],
         notes='Shortening for making rich, buttery baked goods'
     )
-    IngredientSpec(
-        **_ingredient_kwargs(butter),
+    _make_ingredient(
+        material=butter,
         labels=['wet', 'shortening'],
         process=wetmix.process,
         absolute_quantity=NominalReal(nominal=1, units='cups')
     )
-    IngredientSpec(
-        **_ingredient_kwargs(butter),
+    _make_ingredient(
+        material=butter,
         labels=['shortening'],
         process=frosting.process,
         mass_fraction=NominalReal(nominal=0.1434, units='')  # 1/2 c @ 0.911 g/cc
@@ -644,8 +645,8 @@ def make_cake_spec(tmpl=None):
         ],
         notes='A custard waiting to happen'
     )
-    IngredientSpec(
-        **_ingredient_kwargs(eggs),
+    _make_ingredient(
+        material=eggs,
         labels=['wet'],
         absolute_quantity=NominalReal(nominal=4, units='')
     )
@@ -677,14 +678,14 @@ def make_cake_spec(tmpl=None):
             )
         ]
     )
-    IngredientSpec(
-        **_ingredient_kwargs(vanilla),
+    _make_ingredient(
+        material=vanilla,
         labels=['wet', 'flavoring'],
         process=wetmix.process,
         absolute_quantity=NominalReal(nominal=2, units='teaspoons')
     )
-    IngredientSpec(
-        **_ingredient_kwargs(vanilla),
+    _make_ingredient(
+        material=vanilla,
         labels=['flavoring'],
         process=frosting.process,
         mass_fraction=NominalReal(nominal=0.0231, units='')  # 2 tsp @ 0.879 g/cc
@@ -709,14 +710,14 @@ def make_cake_spec(tmpl=None):
         ],
         notes=''
     )
-    IngredientSpec(
-        **_ingredient_kwargs(milk),
+    _make_ingredient(
+        material=milk,
         labels=['wet'],
         process=batter.process,
         absolute_quantity=NominalReal(nominal=1, units='cup')
     )
-    IngredientSpec(
-        **_ingredient_kwargs(milk),
+    _make_ingredient(
+        material=milk,
         labels=[],
         process=frosting.process,
         mass_fraction=NominalReal(nominal=0.0816, units='')  # 1/4 c @ 1.037 g/cc
@@ -739,8 +740,8 @@ def make_cake_spec(tmpl=None):
         ],
         notes=''
     )
-    IngredientSpec(
-        **_ingredient_kwargs(chocolate),
+    _make_ingredient(
+        material=chocolate,
         labels=['flavoring'],
         process=frosting.process,
         mass_fraction=NominalReal(nominal=0.1132, units='')  # 3 oz.
@@ -765,8 +766,8 @@ def make_cake_spec(tmpl=None):
         ],
         notes='Granulated sugar mixed with corn starch'
     )
-    IngredientSpec(
-        **_ingredient_kwargs(powder_sugar),
+    _make_ingredient(
+        material=powder_sugar,
         labels=['flavoring'],
         process=frosting.process,
         mass_fraction=NominalReal(nominal=0.6387, units='')  # 4 c @ 30 g/ 0.25 cups

--- a/gemd/demo/cake.py
+++ b/gemd/demo/cake.py
@@ -122,8 +122,8 @@ def make_cake_templates():
     )
 
     # Objects
-    tmpl["Baking in an oven"] = ProcessTemplate(
-        name="Baking in an oven",
+    tmpl["Baking"] = ProcessTemplate(
+        name="Baking",
         description='Using heat to promote chemical reactions in a material',
         allowed_labels=['precursor'],
         conditions=[(tmpl["Oven temperature"], RealBounds(0, 700, "degF"))],
@@ -183,8 +183,8 @@ def make_cake_templates():
                                      description='Physically combining ingredients',
                                      allowed_labels=['wet', 'dry', 'leavening', 'seasoning',
                                                      'sweetener', 'shortening', 'flavoring'])
-    tmpl["Procurement"] = ProcessTemplate(name="Procurement",
-                                          description="Buyin' stuff")
+    tmpl["Procuring"] = ProcessTemplate(name="Procuring",
+                                        description="Obtaining materials from a third party.")
 
     for key in tmpl:
         tmpl[key].add_uid(DEMO_SCOPE + "-template", key)
@@ -198,31 +198,40 @@ def make_cake_spec(tmpl=None):
     if tmpl is None:
         tmpl = make_cake_templates()
 
-    count = dict()
-
     def ingredient_kwargs(material):
         # Pulls the elements of a material that all ingredients consume out
-        count[material.name] = count.get(material.name, 0) + 1
         return {
-            "name": "{} input{}".format(material.name.replace('Abstract ', ''),
-                                        " (Again)" * (count[material.name] - 1)),
+            "name": material.name.lower(),
             "tags": list(material.tags),
             "material": material
         }
 
+    def material_kwargs(material_name, process_tmpl_name, process_kwargs):
+        # Handles some nicities in naming
+        return {
+            "name": material_name,
+            "process": ProcessSpec(
+                name="{} {}".format(process_tmpl_name, material_name),
+                template=tmpl[process_tmpl_name],
+                **process_kwargs
+            ),
+        }
+
+
     ###############################################################################################
     # Objects
     cake = MaterialSpec(
-        name="Abstract Cake",
-        template=tmpl["Dessert"],
-        process=ProcessSpec(
-            name='Icing Cake, in General',
-            template=tmpl["Icing"],
-            tags=[
-                'spreading'
-            ],
-            notes='The act of covering a baked output with frosting'
+        **material_kwargs(
+            material_name="Cake",
+            process_tmpl_name="Icing",
+            process_kwargs={
+                "tags": [
+                         'spreading'
+                     ],
+                "notes": 'The act of covering a baked output with frosting'
+            }
         ),
+        template=tmpl["Dessert"],
         properties=[
             PropertyAndConditions(Property(name="Tastiness",
                                            value=NominalInteger(5),
@@ -244,16 +253,17 @@ def make_cake_spec(tmpl=None):
 
     ########################
     frosting = MaterialSpec(
-        name="Abstract Frosting",
-        template=tmpl["Dessert"],
-        process=ProcessSpec(
-            name='Mixing Frosting, in General',
-            template=tmpl["Mixing"],
-            tags=[
-                'mixing'
-            ],
-            notes='Combining ingredients to make a sweet frosting'
+        **material_kwargs(
+            material_name="Frosting",
+            process_tmpl_name="Mixing",
+            process_kwargs={
+                "tags": [
+                    'mixing'
+                ],
+                "notes": 'Combining ingredients to make a sweet frosting'
+            }
         ),
+        template=tmpl["Dessert"],
         tags=[
             'frosting::chocolate',
             'topping::chocolate'
@@ -269,17 +279,19 @@ def make_cake_spec(tmpl=None):
     )
 
     baked_cake = MaterialSpec(
-        name="Abstract Baked Cake",
-        template=tmpl["Generic Material"],
-        process=ProcessSpec(
-            name='Baking, in General',
-            template=tmpl["Baking in an oven"],
-            tags=[
-                'oven::baking'
-            ],
-            notes='Using heat to convert batter into a solid matrix'
+        **material_kwargs(
+            material_name="Baked Cake",
+            process_tmpl_name="Baking",
+            process_kwargs={
+                "tags": [
+                    'oven::baking'
+                ],
+                "notes": 'Using heat to convert batter into a solid matrix'
+            }
         ),
+        template=tmpl["Generic Material"],
         tags=[
+            'substrate'
         ],
         notes='The cakey part of the cake'
     )
@@ -291,17 +303,19 @@ def make_cake_spec(tmpl=None):
 
     ########################
     batter = MaterialSpec(
-        name="Abstract Batter",
-        template=tmpl["Generic Material"],
-        process=ProcessSpec(
-            name='Mixing Batter, in General',
-            template=tmpl["Mixing"],
-            tags=[
-                'mixing'
-            ],
-            notes='Combining ingredients to make a baking feedstock'
+        **material_kwargs(
+            material_name="Batter",
+            process_tmpl_name="Mixing",
+            process_kwargs={
+                "tags": [
+                    'mixing'
+                ],
+                "notes": 'Combining ingredients to make a baking feedstock'
+            }
         ),
+        template=tmpl["Generic Material"],
         tags=[
+            'mixture'
         ],
         notes='The fluid that converts to cake with heat'
     )
@@ -313,17 +327,19 @@ def make_cake_spec(tmpl=None):
 
     ########################
     wetmix = MaterialSpec(
-        name="Abstract Wet Mix",
-        template=tmpl["Generic Material"],
-        process=ProcessSpec(
-            name='Mixing Wet, in General',
-            template=tmpl["Mixing"],
-            tags=[
-                'mixing'
-            ],
-            notes='Combining wet ingredients to make a baking feedstock'
+        **material_kwargs(
+            material_name="Wet Ingredients",
+            process_tmpl_name="Mixing",
+            process_kwargs={
+                "tags": [
+                    'mixing'
+                ],
+                "notes": 'Combining wet ingredients to make a baking feedstock'
+            }
         ),
+        template=tmpl["Generic Material"],
         tags=[
+            "mixture"
         ],
         notes='The wet fraction of a batter'
     )
@@ -334,17 +350,19 @@ def make_cake_spec(tmpl=None):
     )
 
     drymix = MaterialSpec(
-        name="Abstract Dry Mix",
-        template=tmpl["Generic Material"],
-        process=ProcessSpec(
-            name='Mixing Dry, in General',
-            template=tmpl["Mixing"],
-            tags=[
-                'mixing'
-            ],
-            notes='Combining dry ingredients to make a baking feedstock'
+        **material_kwargs(
+            material_name="Dry Ingredients",
+            process_tmpl_name="Mixing",
+            process_kwargs={
+                "tags": [
+                    'mixing'
+                ],
+                "notes": 'Combining dry ingredients to make a baking feedstock'
+            }
         ),
+        template=tmpl["Generic Material"],
         tags=[
+            "mixture"
         ],
         notes='The dry fraction of a batter'
     )
@@ -357,7 +375,16 @@ def make_cake_spec(tmpl=None):
 
     ########################
     flour = MaterialSpec(
-        name="Abstract Flour",
+        **material_kwargs(
+            material_name="Flour",
+            process_tmpl_name="Procuring",
+            process_kwargs={
+                "tags": [
+                    'purchase::dry-goods'
+                ],
+                "notes": 'Purchasing all purpose flour'
+            }
+        ),
         template=tmpl["Nutritional Material"],
         properties=[
             PropertyAndConditions(
@@ -383,15 +410,10 @@ def make_cake_spec(tmpl=None):
                 )
             )
         ],
-        process=ProcessSpec(
-            name='Buying Flour, in General',
-            template=tmpl["Procurement"],
-            tags=[
-                'purchase::dry-goods'
-            ],
-            notes='Purchasing all purpose flour'
-        ),
         tags=[
+            'raw material',
+            'flour',
+            'dry-goods'
         ],
         notes='All-purpose flour'
     )
@@ -403,17 +425,21 @@ def make_cake_spec(tmpl=None):
     )
 
     baking_powder = MaterialSpec(
-        name="Abstract Baking Powder",
-        template=tmpl["Generic Material"],
-        process=ProcessSpec(
-            name='Buying Baking Powder, in General',
-            template=tmpl["Procurement"],
-            tags=[
-                'purchase::dry-goods'
-            ],
-            notes='Purchasing baking powder'
+        **material_kwargs(
+            material_name="Baking Powder",
+            process_tmpl_name="Procuring",
+            process_kwargs={
+                "tags": [
+                    'purchase::dry-goods'
+                ],
+                "notes": 'Purchasing baking powder'
+            }
         ),
+        template=tmpl["Generic Material"],
         tags=[
+            'raw material',
+            'levening',
+            'dry-goods'
         ],
         notes='Leavening agent for cake'
     )
@@ -425,17 +451,21 @@ def make_cake_spec(tmpl=None):
     )
 
     salt = MaterialSpec(
-        name="Abstract Salt",
-        template=tmpl["Formulaic Material"],
-        process=ProcessSpec(
-            name='Buying Salt, in General',
-            template=tmpl["Procurement"],
-            tags=[
-                'purchase::dry-goods'
-            ],
-            notes='Purchasing salt'
+        **material_kwargs(
+            material_name="Salt",
+            process_tmpl_name="Procuring",
+            process_kwargs={
+                "tags": [
+                    'purchase::dry-goods'
+                ],
+                "notes": 'Purchasing salt'
+            }
         ),
+        template=tmpl["Formulaic Material"],
         tags=[
+            'raw material',
+            'seasoning',
+            'dry-goods'
         ],
         notes='Plain old NaCl',
         properties=[
@@ -450,17 +480,21 @@ def make_cake_spec(tmpl=None):
     )
 
     sugar = MaterialSpec(
-        name="Abstract Sugar",
-        template=tmpl["Formulaic Material"],
-        process=ProcessSpec(
-            name='Buying Sugar, in General',
-            template=tmpl["Procurement"],
-            tags=[
-                'purchase::dry-goods'
-            ],
-            notes='Purchasing all purpose flour'
+        **material_kwargs(
+            material_name="Sugar",
+            process_tmpl_name="Procuring",
+            process_kwargs={
+                "tags": [
+                    'purchase::dry-goods'
+                ],
+                "notes": 'Purchasing all purpose flour'
+            }
         ),
+        template=tmpl["Formulaic Material"],
         tags=[
+            'raw material',
+            'sweetener',
+            'dry-goods'
         ],
         notes='Sugar',
         properties=[
@@ -481,17 +515,22 @@ def make_cake_spec(tmpl=None):
     )
 
     butter = MaterialSpec(
-        name="Abstract Butter",
-        template=tmpl["Generic Material"],
-        process=ProcessSpec(
-            name='Buying Butter, in General',
-            template=tmpl["Procurement"],
-            tags=[
-                'purchase::produce'
-            ],
-            notes='Purchasing butter'
+        **material_kwargs(
+            material_name="Butter",
+            process_tmpl_name="Procuring",
+            process_kwargs={
+                "tags": [
+                    'purchase::produce'
+                ],
+                "notes": 'Purchasing butter'
+            }
         ),
+        template=tmpl["Generic Material"],
         tags=[
+            'raw material',
+            'produce',
+            'shortening',
+            'dairy'
         ],
         notes='Shortening for making rich, buttery baked goods'
     )
@@ -509,19 +548,22 @@ def make_cake_spec(tmpl=None):
     )
 
     eggs = MaterialSpec(
-        name="Abstract Eggs",
-        template=tmpl["Generic Material"],
-        process=ProcessSpec(
-            name='Buying Eggs, in General',
-            template=tmpl["Procurement"],
-            tags=[
-                'purchase::produce'
-            ],
-            notes='Purchasing eggs'
+        **material_kwargs(
+            material_name="Eggs",
+            process_tmpl_name="Procuring",
+            process_kwargs={
+                "tags": [
+                    'purchase::produce'
+                ],
+                "notes": 'Purchasing eggs'
+            }
         ),
+        template=tmpl["Generic Material"],
         tags=[
+            'raw material',
+            'produce',
         ],
-        notes=''
+        notes='A custard waiting to happen'
     )
     IngredientSpec(
         **ingredient_kwargs(eggs),
@@ -530,17 +572,20 @@ def make_cake_spec(tmpl=None):
     )
 
     vanilla = MaterialSpec(
-        name="Abstract Vanilla",
-        template=tmpl["Generic Material"],
-        process=ProcessSpec(
-            name='Buying Vanilla, in General',
-            template=tmpl["Procurement"],
-            tags=[
-                'purchase::dry-goods'
-            ],
-            notes='Purchasing vanilla'
+        **material_kwargs(
+            material_name="Vanilla",
+            process_tmpl_name="Procuring",
+            process_kwargs={
+                "tags": [
+                    'purchase::solution'
+                ],
+                "notes": 'Purchasing vanilla'
+            }
         ),
+        template=tmpl["Generic Material"],
         tags=[
+            'raw material',
+            'seasoning'
         ],
         notes='Vanilla Extract is mostly alcohol but the most important component '
               'is vanillin (see attached structure)',
@@ -567,17 +612,20 @@ def make_cake_spec(tmpl=None):
     )
 
     milk = MaterialSpec(
-        name="Abstract Milk",
-        template=tmpl["Generic Material"],
-        process=ProcessSpec(
-            name='Buying Milk, in General',
-            template=tmpl["Procurement"],
-            tags=[
-                'purchase::produce'
-            ],
-            notes='Purchasing milk'
+        **material_kwargs(
+            material_name="Milk",
+            process_tmpl_name="Procuring",
+            process_kwargs={
+                "tags": [
+                    'purchase::produce'
+                ],
+                "notes": 'Purchasing milk'
+            }
         ),
         tags=[
+            'raw material',
+            'produce',
+            'dairy'
         ],
         notes=''
     )
@@ -595,17 +643,18 @@ def make_cake_spec(tmpl=None):
     )
 
     chocolate = MaterialSpec(
-        name="Abstract Chocolate",
-        template=tmpl["Generic Material"],
-        process=ProcessSpec(
-            name='Buying Chocolate, in General',
-            template=tmpl["Procurement"],
-            tags=[
-                'purchase::dry-goods'
-            ],
-            notes='Purchasing chocolate'
+        **material_kwargs(
+            material_name="Chocolate",
+            process_tmpl_name="Procuring",
+            process_kwargs={
+                "tags": [
+                    'purchase::dry-goods'
+                ],
+                "notes": 'Purchasing chocolate'
+            }
         ),
         tags=[
+            'raw material'
         ],
         notes=''
     )
@@ -617,17 +666,21 @@ def make_cake_spec(tmpl=None):
     )
 
     powder_sugar = MaterialSpec(
-        name="Abstract Powdered Sugar",
-        template=tmpl["Generic Material"],
-        process=ProcessSpec(
-            name='Buying Powdered Sugar, in General',
-            template=tmpl["Procurement"],
-            tags=[
-                'purchase::dry-goods'
-            ],
-            notes='Purchasing powdered sugar'
+        **material_kwargs(
+            material_name="Powdered Sugar",
+            process_tmpl_name="Procuring",
+            process_kwargs={
+                "tags": [
+                    'purchase::dry-goods'
+                ],
+                "notes": 'Purchasing powdered sugar'
+            }
         ),
+        template=tmpl["Generic Material"],
         tags=[
+            'raw material',
+            'sweetener',
+            'dry-goods'
         ],
         notes='Granulated sugar mixed with corn starch'
     )
@@ -639,7 +692,18 @@ def make_cake_spec(tmpl=None):
     )
 
     # Crawl tree and annotate with uids; only add ids if there's nothing there
-    recursive_foreach(cake, lambda obj: obj.uids or obj.add_uid(DEMO_SCOPE, obj.name))
+    seen = set()
+
+    def name_fuzz(obj):
+        # Add fuzz to name in ID as necessary
+        nonlocal seen
+        name = 'ing-' if isinstance(obj, IngredientSpec) else ''
+        name += obj.name
+        while name.lower() in seen:
+            name += '-again'
+        seen.add(name.lower())
+        return name
+    recursive_foreach(cake, lambda obj: obj.uids or obj.add_uid(DEMO_SCOPE, name_fuzz(obj)))
 
     return cake
 
@@ -662,6 +726,8 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
     # Objects
     cake = make_instance(cake_spec)
     operators = ['gwash', 'jadams', 'thomasj', 'jmadison', 'jmonroe']
+    producers = ['Fresh Farm', 'Sunnydale', 'Greenbrook']
+    drygoods = ['Acme', 'A1', 'Reliable', "Big Box"]
     cake.process.source = PerformedSource(performed_by=random.choice(operators),
                                           performed_date='2015-03-14')
     # Replace Abstract/In General
@@ -670,18 +736,22 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
         item = queue.pop(0)
         if item.spec.tags is not None:
             item.tags = list(item.spec.tags)
-        if item.spec.notes:  # None or empty string
+        if item.spec.notes:  # Neither None or empty string
             item.notes = 'The spec says "{}"'.format(item.spec.notes)
-
         if isinstance(item, MaterialRun):
-            item.name = item.name.replace('Abstract ', '')
+            if 'raw material' in item.tags:
+                if 'produce' in item.tags:
+                    supplier = random.choice(producers)
+                else:
+                    supplier = random.choice(drygoods)
+                item.name = "{} {}".format(supplier, item.spec.name)
             queue.append(item.process)
         elif isinstance(item, ProcessRun):
-            item.name = item.name.replace(', in General', '')
             queue.extend(item.ingredients)
-            if item.template.name == "Procurement":
+            if item.template.name == "Procuring":
                 item.source = PerformedSource(performed_by='hamilton',
                                               performed_date='2015-02-17')
+                item.name = "{} {}".format(item.template.name, item.output_material.name)
             else:
                 item.source = cake.process.source
         elif isinstance(item, IngredientRun):

--- a/gemd/demo/cake.py
+++ b/gemd/demo/cake.py
@@ -233,16 +233,16 @@ def make_cake_spec(tmpl=None):
     if tmpl is None:
         tmpl = make_cake_templates()
 
-    def ingredient_kwargs(material):
-        # Pulls the elements of a material that all ingredients consume out
+    def _ingredient_kwargs(material):
+        """Convenience method to utilize material fields in creating an ingredient's arguments."""
         return {
             "name": material.name.lower(),
             "tags": list(material.tags),
             "material": material
         }
 
-    def material_kwargs(material_name, process_tmpl_name, process_kwargs):
-        # Handles some nicities in naming
+    def _material_kwargs(material_name, process_tmpl_name, process_kwargs):
+        """Convenience method to reuse material name in creating a material's arguments."""
         return {
             "name": material_name,
             "process": ProcessSpec(
@@ -255,7 +255,7 @@ def make_cake_spec(tmpl=None):
     ###############################################################################################
     # Objects
     cake = MaterialSpec(
-        **material_kwargs(
+        **_material_kwargs(
             material_name="Cake",
             process_tmpl_name="Icing",
             process_kwargs={
@@ -285,7 +285,7 @@ def make_cake_spec(tmpl=None):
 
     ########################
     frosting = MaterialSpec(
-        **material_kwargs(
+        **_material_kwargs(
             material_name="Frosting",
             process_tmpl_name="Mixing",
             process_kwargs={
@@ -309,7 +309,7 @@ def make_cake_spec(tmpl=None):
         notes='Chocolate frosting'
     )
     IngredientSpec(
-        **ingredient_kwargs(frosting),
+        **_ingredient_kwargs(frosting),
         notes='Seems like a lot of frosting',
         labels=['coating'],
         process=cake.process,
@@ -317,7 +317,7 @@ def make_cake_spec(tmpl=None):
     )
 
     baked_cake = MaterialSpec(
-        **material_kwargs(
+        **_material_kwargs(
             material_name="Baked Cake",
             process_tmpl_name="Baking",
             process_kwargs={
@@ -363,14 +363,14 @@ def make_cake_spec(tmpl=None):
         notes='The cakey part of the cake'
     )
     IngredientSpec(
-        **ingredient_kwargs(baked_cake),
+        **_ingredient_kwargs(baked_cake),
         labels=['substrate'],
         process=cake.process
     )
 
     ########################
     batter = MaterialSpec(
-        **material_kwargs(
+        **_material_kwargs(
             material_name="Batter",
             process_tmpl_name="Mixing",
             process_kwargs={
@@ -393,14 +393,14 @@ def make_cake_spec(tmpl=None):
         notes='The fluid that converts to cake with heat'
     )
     IngredientSpec(
-        **ingredient_kwargs(batter),
+        **_ingredient_kwargs(batter),
         labels=['precursor'],
         process=baked_cake.process
     )
 
     ########################
     wetmix = MaterialSpec(
-        **material_kwargs(
+        **_material_kwargs(
             material_name="Wet Ingredients",
             process_tmpl_name="Mixing",
             process_kwargs={
@@ -423,13 +423,13 @@ def make_cake_spec(tmpl=None):
         notes='The wet fraction of a batter'
     )
     IngredientSpec(
-        **ingredient_kwargs(wetmix),
+        **_ingredient_kwargs(wetmix),
         labels=['wet'],
         process=batter.process
     )
 
     drymix = MaterialSpec(
-        **material_kwargs(
+        **_material_kwargs(
             material_name="Dry Ingredients",
             process_tmpl_name="Mixing",
             process_kwargs={
@@ -446,7 +446,7 @@ def make_cake_spec(tmpl=None):
         notes='The dry fraction of a batter'
     )
     IngredientSpec(
-        **ingredient_kwargs(drymix),
+        **_ingredient_kwargs(drymix),
         labels=['dry'],
         process=batter.process,
         absolute_quantity=NominalReal(nominal=3.052, units='cups')
@@ -454,7 +454,7 @@ def make_cake_spec(tmpl=None):
 
     ########################
     flour = MaterialSpec(
-        **material_kwargs(
+        **_material_kwargs(
             material_name="Flour",
             process_tmpl_name="Procuring",
             process_kwargs={
@@ -497,14 +497,14 @@ def make_cake_spec(tmpl=None):
         notes='All-purpose flour'
     )
     IngredientSpec(
-        **ingredient_kwargs(flour),
+        **_ingredient_kwargs(flour),
         labels=['dry'],
         process=drymix.process,
         volume_fraction=NominalReal(nominal=0.9829, units='')  # 3 cups
     )
 
     baking_powder = MaterialSpec(
-        **material_kwargs(
+        **_material_kwargs(
             material_name="Baking Powder",
             process_tmpl_name="Procuring",
             process_kwargs={
@@ -523,14 +523,14 @@ def make_cake_spec(tmpl=None):
         notes='Leavening agent for cake'
     )
     IngredientSpec(
-        **ingredient_kwargs(baking_powder),
+        **_ingredient_kwargs(baking_powder),
         labels=['leavening', 'dry'],
         process=drymix.process,
         volume_fraction=NominalReal(nominal=0.0137, units='')  # 2 teaspoons
     )
 
     salt = MaterialSpec(
-        **material_kwargs(
+        **_material_kwargs(
             material_name="Salt",
             process_tmpl_name="Procuring",
             process_kwargs={
@@ -552,14 +552,14 @@ def make_cake_spec(tmpl=None):
         ]
     )
     IngredientSpec(
-        **ingredient_kwargs(salt),
+        **_ingredient_kwargs(salt),
         labels=['dry', 'seasoning'],
         process=drymix.process,
         volume_fraction=NominalReal(nominal=0.0034, units='')  # 1/2 teaspoon
     )
 
     sugar = MaterialSpec(
-        **material_kwargs(
+        **_material_kwargs(
             material_name="Sugar",
             process_tmpl_name="Procuring",
             process_kwargs={
@@ -587,14 +587,14 @@ def make_cake_spec(tmpl=None):
         ]
     )
     IngredientSpec(
-        **ingredient_kwargs(sugar),
+        **_ingredient_kwargs(sugar),
         labels=['wet', 'sweetener'],
         process=wetmix.process,
         absolute_quantity=NominalReal(nominal=2, units='cups')
     )
 
     butter = MaterialSpec(
-        **material_kwargs(
+        **_material_kwargs(
             material_name="Butter",
             process_tmpl_name="Procuring",
             process_kwargs={
@@ -614,20 +614,20 @@ def make_cake_spec(tmpl=None):
         notes='Shortening for making rich, buttery baked goods'
     )
     IngredientSpec(
-        **ingredient_kwargs(butter),
+        **_ingredient_kwargs(butter),
         labels=['wet', 'shortening'],
         process=wetmix.process,
         absolute_quantity=NominalReal(nominal=1, units='cups')
     )
     IngredientSpec(
-        **ingredient_kwargs(butter),
+        **_ingredient_kwargs(butter),
         labels=['shortening'],
         process=frosting.process,
         mass_fraction=NominalReal(nominal=0.1434, units='')  # 1/2 c @ 0.911 g/cc
     )
 
     eggs = MaterialSpec(
-        **material_kwargs(
+        **_material_kwargs(
             material_name="Eggs",
             process_tmpl_name="Procuring",
             process_kwargs={
@@ -645,13 +645,13 @@ def make_cake_spec(tmpl=None):
         notes='A custard waiting to happen'
     )
     IngredientSpec(
-        **ingredient_kwargs(eggs),
+        **_ingredient_kwargs(eggs),
         labels=['wet'],
         absolute_quantity=NominalReal(nominal=4, units='')
     )
 
     vanilla = MaterialSpec(
-        **material_kwargs(
+        **_material_kwargs(
             material_name="Vanilla",
             process_tmpl_name="Procuring",
             process_kwargs={
@@ -678,20 +678,20 @@ def make_cake_spec(tmpl=None):
         ]
     )
     IngredientSpec(
-        **ingredient_kwargs(vanilla),
+        **_ingredient_kwargs(vanilla),
         labels=['wet', 'flavoring'],
         process=wetmix.process,
         absolute_quantity=NominalReal(nominal=2, units='teaspoons')
     )
     IngredientSpec(
-        **ingredient_kwargs(vanilla),
+        **_ingredient_kwargs(vanilla),
         labels=['flavoring'],
         process=frosting.process,
         mass_fraction=NominalReal(nominal=0.0231, units='')  # 2 tsp @ 0.879 g/cc
     )
 
     milk = MaterialSpec(
-        **material_kwargs(
+        **_material_kwargs(
             material_name="Milk",
             process_tmpl_name="Procuring",
             process_kwargs={
@@ -710,20 +710,20 @@ def make_cake_spec(tmpl=None):
         notes=''
     )
     IngredientSpec(
-        **ingredient_kwargs(milk),
+        **_ingredient_kwargs(milk),
         labels=['wet'],
         process=batter.process,
         absolute_quantity=NominalReal(nominal=1, units='cup')
     )
     IngredientSpec(
-        **ingredient_kwargs(milk),
+        **_ingredient_kwargs(milk),
         labels=[],
         process=frosting.process,
         mass_fraction=NominalReal(nominal=0.0816, units='')  # 1/4 c @ 1.037 g/cc
     )
 
     chocolate = MaterialSpec(
-        **material_kwargs(
+        **_material_kwargs(
             material_name="Chocolate",
             process_tmpl_name="Procuring",
             process_kwargs={
@@ -740,14 +740,14 @@ def make_cake_spec(tmpl=None):
         notes=''
     )
     IngredientSpec(
-        **ingredient_kwargs(chocolate),
+        **_ingredient_kwargs(chocolate),
         labels=['flavoring'],
         process=frosting.process,
         mass_fraction=NominalReal(nominal=0.1132, units='')  # 3 oz.
     )
 
     powder_sugar = MaterialSpec(
-        **material_kwargs(
+        **_material_kwargs(
             material_name="Powdered Sugar",
             process_tmpl_name="Procuring",
             process_kwargs={
@@ -766,7 +766,7 @@ def make_cake_spec(tmpl=None):
         notes='Granulated sugar mixed with corn starch'
     )
     IngredientSpec(
-        **ingredient_kwargs(powder_sugar),
+        **_ingredient_kwargs(powder_sugar),
         labels=['flavoring'],
         process=frosting.process,
         mass_fraction=NominalReal(nominal=0.6387, units='')  # 4 c @ 30 g/ 0.25 cups
@@ -873,19 +873,19 @@ def make_cake(seed=None, tmpl=None, cake_spec=None, toothpick_img=None):
     baked = \
         next(x.material for x in cake.process.ingredients if 'aked' in x.name)
 
-    def find_name(name, material):
-        # Recursively search for the right material
+    def _find_name(name, material):
+        """Recursively search for the right material."""
         if name in material.name:
             return material
         for ingredient in material.process.ingredients:
-            result = find_name(name, ingredient.material)
+            result = _find_name(name, ingredient.material)
             if result:
                 return result
         return
 
-    flour = find_name('Flour', cake)
-    salt = find_name('Salt', cake)
-    sugar = find_name('Sugar', cake)
+    flour = _find_name('Flour', cake)
+    salt = _find_name('Salt', cake)
+    sugar = _find_name('Sugar', cake)
 
     # Add measurements
     cake_taste = MeasurementRun(name='Final Taste', material=cake)

--- a/gemd/demo/cake.py
+++ b/gemd/demo/cake.py
@@ -30,6 +30,27 @@ DEMO_SCOPE = 'citrine-demo'
 TEMPLATE_SCOPE = DEMO_SCOPE + '-template'
 
 
+def change_scope(data, *, templates=None):
+    """
+    Change scope(s) of internal uids.
+
+    Parameters
+    ----------
+    data: str
+        Scope for the Run and Spec objects
+    templates: str, optional
+        Scope for the Attribute Templates and Object Templates.  If `None`,
+        will be set to `data + '-template'`
+
+    """
+    global DEMO_SCOPE, TEMPLATE_SCOPE
+    DEMO_SCOPE = data
+    if templates is None:
+        TEMPLATE_SCOPE = DEMO_SCOPE + '-template'
+    else:
+        TEMPLATE_SCOPE = templates
+
+
 def import_toothpick_picture():
     """Return the stream of the toothpick picture."""
     import pkg_resources

--- a/gemd/demo/cake.py
+++ b/gemd/demo/cake.py
@@ -27,6 +27,7 @@ from gemd.util.impl import recursive_foreach
 
 # For now, module constant, though likely this should get promoted to a package level
 DEMO_SCOPE = 'citrine-demo'
+TEMPLATE_SCOPE = DEMO_SCOPE + '-template'
 
 
 def import_toothpick_picture():
@@ -196,7 +197,7 @@ def make_cake_templates():
     )
 
     for key in tmpl:
-        tmpl[key].add_uid(DEMO_SCOPE + "-template", key)
+        tmpl[key].add_uid(TEMPLATE_SCOPE, key)
     return tmpl
 
 

--- a/gemd/demo/cake.py
+++ b/gemd/demo/cake.py
@@ -42,6 +42,12 @@ def make_cake_templates():
     tmpl = dict()
 
     # Attributes
+    tmpl["Mixer speed setting"] = ParameterTemplate(
+        name="Mixer speed setting",
+        description="What speed setting to use on the mixer",
+        bounds=IntegerBounds(0, 10)
+    )
+
     tmpl['Cooking time'] = ConditionTemplate(
         name="Cooking time",
         description="The time elapsed during a cooking process",
@@ -142,7 +148,8 @@ def make_cake_templates():
         name="Mixing",
         description='Physically combining ingredients',
         allowed_labels=['wet', 'dry', 'leavening', 'seasoning',
-                        'sweetener', 'shortening', 'flavoring']
+                        'sweetener', 'shortening', 'flavoring'],
+        parameters=[tmpl["Mixer speed setting"]]
     )
 
     tmpl["Generic Material"] = MaterialTemplate(name="Generic")
@@ -262,6 +269,12 @@ def make_cake_spec(tmpl=None):
                 "tags": [
                     'mixing'
                 ],
+                "parameters": [
+                    Parameter(name='Mixer speed setting',
+                              template=tmpl['Mixer speed setting'],
+                              origin='specified',
+                              value=NominalInteger(2))
+                ],
                 "notes": 'Combining ingredients to make a sweet frosting'
             }
         ),
@@ -312,6 +325,12 @@ def make_cake_spec(tmpl=None):
                 "tags": [
                     'mixing'
                 ],
+                "parameters": [
+                    Parameter(name='Mixer speed setting',
+                              template=tmpl['Mixer speed setting'],
+                              origin='specified',
+                              value=NominalInteger(2))
+                ],
                 "notes": 'Combining ingredients to make a baking feedstock'
             }
         ),
@@ -335,6 +354,12 @@ def make_cake_spec(tmpl=None):
             process_kwargs={
                 "tags": [
                     'mixing'
+                ],
+                "parameters": [
+                    Parameter(name='Mixer speed setting',
+                              template=tmpl['Mixer speed setting'],
+                              origin='specified',
+                              value=NominalInteger(2))
                 ],
                 "notes": 'Combining wet ingredients to make a baking feedstock'
             }

--- a/gemd/demo/cake.py
+++ b/gemd/demo/cake.py
@@ -242,28 +242,26 @@ def make_cake_spec(tmpl=None):
             **kwargs
         )
 
-    def _material_kwargs(material_name, process_tmpl_name, process_kwargs):
+    def _make_material(material_name, process_tmpl_name, process_kwargs, **material_kwargs):
         """Convenience method to reuse material name in creating a material's arguments."""
-        return {
-            "name": material_name,
-            "process": ProcessSpec(
+        return MaterialSpec(
+            name=material_name,
+            process=ProcessSpec(
                 name="{} {}".format(process_tmpl_name, material_name),
                 template=tmpl[process_tmpl_name],
                 **process_kwargs
             ),
-        }
+            **material_kwargs)
 
     ###############################################################################################
     # Objects
-    cake = MaterialSpec(
-        **_material_kwargs(
-            material_name="Cake",
-            process_tmpl_name="Icing",
-            process_kwargs={
-                "tags": ['spreading'],
-                "notes": 'The act of covering a baked output with frosting'
-            }
-        ),
+    cake = _make_material(
+        material_name="Cake",
+        process_tmpl_name="Icing",
+        process_kwargs={
+            "tags": ['spreading'],
+            "notes": 'The act of covering a baked output with frosting'
+        },
         template=tmpl["Dessert"],
         properties=[
             PropertyAndConditions(Property(name="Tastiness",
@@ -285,23 +283,21 @@ def make_cake_spec(tmpl=None):
     )
 
     ########################
-    frosting = MaterialSpec(
-        **_material_kwargs(
-            material_name="Frosting",
-            process_tmpl_name="Mixing",
-            process_kwargs={
-                "tags": [
-                    'mixing'
-                ],
-                "parameters": [
-                    Parameter(name='Mixer speed setting',
-                              template=tmpl['Mixer speed setting'],
-                              origin='specified',
-                              value=NominalInteger(2))
-                ],
-                "notes": 'Combining ingredients to make a sweet frosting'
-            }
-        ),
+    frosting = _make_material(
+        material_name="Frosting",
+        process_tmpl_name="Mixing",
+        process_kwargs={
+            "tags": [
+                'mixing'
+            ],
+            "parameters": [
+                Parameter(name='Mixer speed setting',
+                          template=tmpl['Mixer speed setting'],
+                          origin='specified',
+                          value=NominalInteger(2))
+            ],
+            "notes": 'Combining ingredients to make a sweet frosting'
+        },
         template=tmpl["Dessert"],
         tags=[
             'frosting::chocolate',
@@ -317,29 +313,27 @@ def make_cake_spec(tmpl=None):
         absolute_quantity=NominalReal(nominal=0.751, units='kg')
     )
 
-    baked_cake = MaterialSpec(
-        **_material_kwargs(
-            material_name="Baked Cake",
-            process_tmpl_name="Baking",
-            process_kwargs={
-                "tags": [
-                    'oven::baking'
-                ],
-                "conditions": [
-                    Condition(name='Cooking time',
-                              template=tmpl['Cooking time'],
-                              origin=Origin.SPECIFIED,
-                              value=NormalReal(mean=50, std=5, units='min'))
-                ],
-                "parameters": [
-                    Parameter(name='Oven temperature setting',
-                              template=tmpl['Oven temperature setting'],
-                              origin="specified",
-                              value=NominalReal(nominal=350, units='degF'))
-                ],
-                "notes": 'Using heat to convert batter into a solid matrix'
-            }
-        ),
+    baked_cake = _make_material(
+        material_name="Baked Cake",
+        process_tmpl_name="Baking",
+        process_kwargs={
+            "tags": [
+                'oven::baking'
+            ],
+            "conditions": [
+                Condition(name='Cooking time',
+                          template=tmpl['Cooking time'],
+                          origin=Origin.SPECIFIED,
+                          value=NormalReal(mean=50, std=5, units='min'))
+            ],
+            "parameters": [
+                Parameter(name='Oven temperature setting',
+                          template=tmpl['Oven temperature setting'],
+                          origin="specified",
+                          value=NominalReal(nominal=350, units='degF'))
+            ],
+            "notes": 'Using heat to convert batter into a solid matrix'
+        },
         template=tmpl["Baked Good"],
         properties=[
             PropertyAndConditions(
@@ -370,23 +364,21 @@ def make_cake_spec(tmpl=None):
     )
 
     ########################
-    batter = MaterialSpec(
-        **_material_kwargs(
-            material_name="Batter",
-            process_tmpl_name="Mixing",
-            process_kwargs={
-                "tags": [
-                    'mixing'
-                ],
-                "parameters": [
-                    Parameter(name='Mixer speed setting',
-                              template=tmpl['Mixer speed setting'],
-                              origin='specified',
-                              value=NominalInteger(2))
-                ],
-                "notes": 'Combining ingredients to make a baking feedstock'
-            }
-        ),
+    batter = _make_material(
+        material_name="Batter",
+        process_tmpl_name="Mixing",
+        process_kwargs={
+            "tags": [
+                'mixing'
+            ],
+            "parameters": [
+                Parameter(name='Mixer speed setting',
+                          template=tmpl['Mixer speed setting'],
+                          origin='specified',
+                          value=NominalInteger(2))
+            ],
+            "notes": 'Combining ingredients to make a baking feedstock'
+        },
         template=tmpl["Generic Material"],
         tags=[
             'mixture'
@@ -400,23 +392,21 @@ def make_cake_spec(tmpl=None):
     )
 
     ########################
-    wetmix = MaterialSpec(
-        **_material_kwargs(
-            material_name="Wet Ingredients",
-            process_tmpl_name="Mixing",
-            process_kwargs={
-                "tags": [
-                    'mixing'
-                ],
-                "parameters": [
-                    Parameter(name='Mixer speed setting',
-                              template=tmpl['Mixer speed setting'],
-                              origin='specified',
-                              value=NominalInteger(2))
-                ],
-                "notes": 'Combining wet ingredients to make a baking feedstock'
-            }
-        ),
+    wetmix = _make_material(
+        material_name="Wet Ingredients",
+        process_tmpl_name="Mixing",
+        process_kwargs={
+            "tags": [
+                'mixing'
+            ],
+            "parameters": [
+                Parameter(name='Mixer speed setting',
+                          template=tmpl['Mixer speed setting'],
+                          origin='specified',
+                          value=NominalInteger(2))
+            ],
+            "notes": 'Combining wet ingredients to make a baking feedstock'
+        },
         template=tmpl["Generic Material"],
         tags=[
             "mixture"
@@ -429,17 +419,15 @@ def make_cake_spec(tmpl=None):
         process=batter.process
     )
 
-    drymix = MaterialSpec(
-        **_material_kwargs(
-            material_name="Dry Ingredients",
-            process_tmpl_name="Mixing",
-            process_kwargs={
-                "tags": [
-                    'mixing'
-                ],
-                "notes": 'Combining dry ingredients to make a baking feedstock'
-            }
-        ),
+    drymix = _make_material(
+        material_name="Dry Ingredients",
+        process_tmpl_name="Mixing",
+        process_kwargs={
+            "tags": [
+                'mixing'
+            ],
+            "notes": 'Combining dry ingredients to make a baking feedstock'
+        },
         template=tmpl["Generic Material"],
         tags=[
             "mixture"
@@ -454,17 +442,15 @@ def make_cake_spec(tmpl=None):
     )
 
     ########################
-    flour = MaterialSpec(
-        **_material_kwargs(
-            material_name="Flour",
-            process_tmpl_name="Procuring",
-            process_kwargs={
-                "tags": [
-                    'purchase::dry-goods'
-                ],
-                "notes": 'Purchasing all purpose flour'
-            }
-        ),
+    flour = _make_material(
+        material_name="Flour",
+        process_tmpl_name="Procuring",
+        process_kwargs={
+            "tags": [
+                'purchase::dry-goods'
+            ],
+            "notes": 'Purchasing all purpose flour'
+        },
         template=tmpl["Nutritional Material"],
         properties=[
             PropertyAndConditions(
@@ -504,17 +490,15 @@ def make_cake_spec(tmpl=None):
         volume_fraction=NominalReal(nominal=0.9829, units='')  # 3 cups
     )
 
-    baking_powder = MaterialSpec(
-        **_material_kwargs(
-            material_name="Baking Powder",
-            process_tmpl_name="Procuring",
-            process_kwargs={
-                "tags": [
-                    'purchase::dry-goods'
-                ],
-                "notes": 'Purchasing baking powder'
-            }
-        ),
+    baking_powder = _make_material(
+        material_name="Baking Powder",
+        process_tmpl_name="Procuring",
+        process_kwargs={
+            "tags": [
+                'purchase::dry-goods'
+            ],
+            "notes": 'Purchasing baking powder'
+        },
         template=tmpl["Generic Material"],
         tags=[
             'raw material',
@@ -530,17 +514,15 @@ def make_cake_spec(tmpl=None):
         volume_fraction=NominalReal(nominal=0.0137, units='')  # 2 teaspoons
     )
 
-    salt = MaterialSpec(
-        **_material_kwargs(
-            material_name="Salt",
-            process_tmpl_name="Procuring",
-            process_kwargs={
-                "tags": [
-                    'purchase::dry-goods'
-                ],
-                "notes": 'Purchasing salt'
-            }
-        ),
+    salt = _make_material(
+        material_name="Salt",
+        process_tmpl_name="Procuring",
+        process_kwargs={
+            "tags": [
+                'purchase::dry-goods'
+            ],
+            "notes": 'Purchasing salt'
+        },
         template=tmpl["Formulaic Material"],
         tags=[
             'raw material',
@@ -559,17 +541,15 @@ def make_cake_spec(tmpl=None):
         volume_fraction=NominalReal(nominal=0.0034, units='')  # 1/2 teaspoon
     )
 
-    sugar = MaterialSpec(
-        **_material_kwargs(
-            material_name="Sugar",
-            process_tmpl_name="Procuring",
-            process_kwargs={
-                "tags": [
-                    'purchase::dry-goods'
-                ],
-                "notes": 'Purchasing all purpose flour'
-            }
-        ),
+    sugar = _make_material(
+        material_name="Sugar",
+        process_tmpl_name="Procuring",
+        process_kwargs={
+            "tags": [
+                'purchase::dry-goods'
+            ],
+            "notes": 'Purchasing all purpose flour'
+        },
         template=tmpl["Formulaic Material"],
         tags=[
             'raw material',
@@ -594,17 +574,15 @@ def make_cake_spec(tmpl=None):
         absolute_quantity=NominalReal(nominal=2, units='cups')
     )
 
-    butter = MaterialSpec(
-        **_material_kwargs(
-            material_name="Butter",
-            process_tmpl_name="Procuring",
-            process_kwargs={
-                "tags": [
-                    'purchase::produce'
-                ],
-                "notes": 'Purchasing butter'
-            }
-        ),
+    butter = _make_material(
+        material_name="Butter",
+        process_tmpl_name="Procuring",
+        process_kwargs={
+            "tags": [
+                'purchase::produce'
+            ],
+            "notes": 'Purchasing butter'
+        },
         template=tmpl["Generic Material"],
         tags=[
             'raw material',
@@ -627,17 +605,15 @@ def make_cake_spec(tmpl=None):
         mass_fraction=NominalReal(nominal=0.1434, units='')  # 1/2 c @ 0.911 g/cc
     )
 
-    eggs = MaterialSpec(
-        **_material_kwargs(
-            material_name="Eggs",
-            process_tmpl_name="Procuring",
-            process_kwargs={
-                "tags": [
-                    'purchase::produce'
-                ],
-                "notes": 'Purchasing eggs'
-            }
-        ),
+    eggs = _make_material(
+        material_name="Eggs",
+        process_tmpl_name="Procuring",
+        process_kwargs={
+            "tags": [
+                'purchase::produce'
+            ],
+            "notes": 'Purchasing eggs'
+        },
         template=tmpl["Generic Material"],
         tags=[
             'raw material',
@@ -651,17 +627,15 @@ def make_cake_spec(tmpl=None):
         absolute_quantity=NominalReal(nominal=4, units='')
     )
 
-    vanilla = MaterialSpec(
-        **_material_kwargs(
-            material_name="Vanilla",
-            process_tmpl_name="Procuring",
-            process_kwargs={
-                "tags": [
-                    'purchase::solution'
-                ],
-                "notes": 'Purchasing vanilla'
-            }
-        ),
+    vanilla = _make_material(
+        material_name="Vanilla",
+        process_tmpl_name="Procuring",
+        process_kwargs={
+            "tags": [
+                'purchase::solution'
+            ],
+            "notes": 'Purchasing vanilla'
+        },
         template=tmpl["Generic Material"],
         tags=[
             'raw material',
@@ -691,17 +665,15 @@ def make_cake_spec(tmpl=None):
         mass_fraction=NominalReal(nominal=0.0231, units='')  # 2 tsp @ 0.879 g/cc
     )
 
-    milk = MaterialSpec(
-        **_material_kwargs(
-            material_name="Milk",
-            process_tmpl_name="Procuring",
-            process_kwargs={
-                "tags": [
-                    'purchase::produce'
-                ],
-                "notes": 'Purchasing milk'
-            }
-        ),
+    milk = _make_material(
+        material_name="Milk",
+        process_tmpl_name="Procuring",
+        process_kwargs={
+            "tags": [
+                'purchase::produce'
+            ],
+            "notes": 'Purchasing milk'
+        },
         template=tmpl["Generic Material"],
         tags=[
             'raw material',
@@ -723,17 +695,15 @@ def make_cake_spec(tmpl=None):
         mass_fraction=NominalReal(nominal=0.0816, units='')  # 1/4 c @ 1.037 g/cc
     )
 
-    chocolate = MaterialSpec(
-        **_material_kwargs(
-            material_name="Chocolate",
-            process_tmpl_name="Procuring",
-            process_kwargs={
-                "tags": [
-                    'purchase::dry-goods'
-                ],
-                "notes": 'Purchasing chocolate'
-            }
-        ),
+    chocolate = _make_material(
+        material_name="Chocolate",
+        process_tmpl_name="Procuring",
+        process_kwargs={
+            "tags": [
+                'purchase::dry-goods'
+            ],
+            "notes": 'Purchasing chocolate'
+        },
         template=tmpl["Generic Material"],
         tags=[
             'raw material'
@@ -747,17 +717,15 @@ def make_cake_spec(tmpl=None):
         mass_fraction=NominalReal(nominal=0.1132, units='')  # 3 oz.
     )
 
-    powder_sugar = MaterialSpec(
-        **_material_kwargs(
-            material_name="Powdered Sugar",
-            process_tmpl_name="Procuring",
-            process_kwargs={
-                "tags": [
-                    'purchase::dry-goods'
-                ],
-                "notes": 'Purchasing powdered sugar'
-            }
-        ),
+    powder_sugar = _make_material(
+        material_name="Powdered Sugar",
+        process_tmpl_name="Procuring",
+        process_kwargs={
+            "tags": [
+                'purchase::dry-goods'
+            ],
+            "notes": 'Purchasing powdered sugar'
+        },
         template=tmpl["Generic Material"],
         tags=[
             'raw material',

--- a/gemd/demo/cake.py
+++ b/gemd/demo/cake.py
@@ -227,7 +227,6 @@ def make_cake_spec(tmpl=None):
             ),
         }
 
-
     ###############################################################################################
     # Objects
     cake = MaterialSpec(
@@ -235,9 +234,7 @@ def make_cake_spec(tmpl=None):
             material_name="Cake",
             process_tmpl_name="Icing",
             process_kwargs={
-                "tags": [
-                         'spreading'
-                     ],
+                "tags": ['spreading'],
                 "notes": 'The act of covering a baked output with frosting'
             }
         ),
@@ -750,7 +747,7 @@ def make_cake_spec(tmpl=None):
     return cake
 
 
-def make_cake(seed=None, tmpl=None, cake_spec=None):
+def make_cake(seed=None, tmpl=None, cake_spec=None, toothpick_img=None):
     """Define all objects that go into making a demo cake."""
     import struct
     import hashlib
@@ -852,6 +849,9 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
     flour_content = MeasurementRun(name='Flour nutritional analysis', material=flour)
     salt_content = MeasurementRun(name='Salt elemental analysis', material=salt)
     sugar_content = MeasurementRun(name='Sugar elemental analysis', material=sugar)
+
+    if toothpick_img is not None:
+        baked_doneness.file_links.append(toothpick_img)
 
     # and spec out the measurements
     cake_taste.spec = MeasurementSpec(name='Taste', template=tmpl['Taste test'])
@@ -1032,7 +1032,10 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
             name_count[name] = 1
             return name
 
-    recursive_foreach(cake, lambda obj: obj.uids or obj.add_uid(DEMO_SCOPE, _disambig(obj.name) + run_key))
+    recursive_foreach(
+        cake,
+        lambda obj: obj.uids or obj.add_uid(DEMO_SCOPE, _disambig(obj.name) + run_key)
+    )
 
     cake.notes = cake.notes + "; Très délicieux! 😀"
     cake.file_links = [FileLink(

--- a/gemd/demo/tests/test_cake.py
+++ b/gemd/demo/tests/test_cake.py
@@ -11,7 +11,7 @@ from gemd.entity.file_link import FileLink
 
 from gemd.json import dumps, loads
 from gemd.demo.cake import make_cake_templates, make_cake_spec, make_cake, \
-    import_toothpick_picture
+    import_toothpick_picture, change_scope
 from gemd.util import recursive_foreach
 from gemd.entity.util import complete_material_history
 
@@ -140,3 +140,27 @@ def test_cake_sigs():
 def test_import():
     """Make sure picture import runs."""
     import_toothpick_picture()
+
+
+def test_scope():
+    """Make sure change scope does what we want it to."""
+    default_cake = make_cake()
+    default_scope = next(iter(default_cake.uids))
+    change_scope('second-scope')
+    second_cake = make_cake()
+    change_scope(data='third-scope', templates='also-a-scope')
+    third_cake = make_cake()
+
+    assert 'second-scope' not in default_cake.uids
+    assert 'third-scope' not in default_cake.uids
+
+    assert default_scope not in second_cake.uids
+    assert 'second-scope' in second_cake.uids
+    assert 'third-scope' not in second_cake.uids
+
+    assert default_scope not in third_cake.uids
+    assert 'second-scope' not in third_cake.uids
+    assert 'third-scope' in third_cake.uids
+
+    assert any('template' in x for x in default_cake.spec.template.uids)
+    assert not any('template' in x for x in third_cake.spec.template.uids)

--- a/gemd/demo/tests/test_cake.py
+++ b/gemd/demo/tests/test_cake.py
@@ -7,16 +7,18 @@ from gemd.entity.object.measurement_spec import MeasurementSpec
 from gemd.entity.object.measurement_run import MeasurementRun
 from gemd.entity.object.ingredient_spec import IngredientSpec
 from gemd.entity.object.ingredient_run import IngredientRun
+from gemd.entity.file_link import FileLink
 
 from gemd.json import dumps, loads
-from gemd.demo.cake import make_cake, import_toothpick_picture
+from gemd.demo.cake import make_cake_templates, make_cake_spec, make_cake, \
+    import_toothpick_picture
 from gemd.util import recursive_foreach
 from gemd.entity.util import complete_material_history
 
 
 def test_cake():
     """Create cake, serialize, deserialize."""
-    cake = make_cake()
+    cake = make_cake(seed=42)
 
     def test_for_loss(obj):
         assert(obj == loads(dumps(obj)))
@@ -112,6 +114,18 @@ def test_cake():
                     assert obj.spec.material == obj.material.spec
             if obj.material:
                 queue.append(obj.material)
+
+
+def test_cake_sigs():
+    """Verify that all arguments for create methods work as expected."""
+    templates = make_cake_templates()
+    specs = make_cake_spec(templates)
+    cake1 = make_cake(seed=27, cake_spec=specs, tmpl=templates)
+    filelink = FileLink(filename='The name of the file', url='www.file.gov')
+    cake2 = make_cake(seed=27, cake_spec=specs, tmpl=templates, toothpick_img=filelink)
+
+    assert filelink.filename not in dumps(cake1)
+    assert filelink.filename in dumps(cake2)
 
 
 def test_import():

--- a/gemd/demo/tests/test_cake.py
+++ b/gemd/demo/tests/test_cake.py
@@ -39,12 +39,12 @@ def test_cake():
         tot_count += 1
 
     recursive_foreach(cake, increment)
-    assert tot_count == 131
+    assert tot_count == 132
 
     # And make sure nothing was lost
     tot_count = 0
     recursive_foreach(loads(dumps(complete_material_history(cake))), increment)
-    assert tot_count == 131
+    assert tot_count == 132
 
     # Check that no UIDs collide
     uid_seen = dict()

--- a/gemd/demo/tests/test_cake.py
+++ b/gemd/demo/tests/test_cake.py
@@ -41,12 +41,12 @@ def test_cake():
         tot_count += 1
 
     recursive_foreach(cake, increment)
-    assert tot_count == 132
+    assert tot_count == 133
 
     # And make sure nothing was lost
     tot_count = 0
     recursive_foreach(loads(dumps(complete_material_history(cake))), increment)
-    assert tot_count == 132
+    assert tot_count == 133
 
     # Check that no UIDs collide
     uid_seen = dict()

--- a/gemd/demo/tests/test_cake.py
+++ b/gemd/demo/tests/test_cake.py
@@ -119,13 +119,22 @@ def test_cake():
 def test_cake_sigs():
     """Verify that all arguments for create methods work as expected."""
     templates = make_cake_templates()
+    tmpl_snap = dumps(templates)
+
     specs = make_cake_spec(templates)
+    spec_snap = dumps(specs)
+    assert dumps(templates) == tmpl_snap
+
     cake1 = make_cake(seed=27, cake_spec=specs, tmpl=templates)
+    assert dumps(templates) == tmpl_snap
+    assert dumps(specs) == spec_snap
+
     filelink = FileLink(filename='The name of the file', url='www.file.gov')
     cake2 = make_cake(seed=27, cake_spec=specs, tmpl=templates, toothpick_img=filelink)
 
     assert filelink.filename not in dumps(cake1)
     assert filelink.filename in dumps(cake2)
+    assert cake1.uids == cake2.uids
 
 
 def test_import():

--- a/gemd/demo/tests/test_cake.py
+++ b/gemd/demo/tests/test_cake.py
@@ -54,7 +54,7 @@ def test_cake():
         for scope in obj.uids:
             lbl = '{}::{}'.format(scope, obj.uids[scope])
             if lbl in uid_seen:
-                assert uid_seen[lbl] == id(obj)
+                assert uid_seen[lbl] == id(obj), "'{}' seen twice".format(lbl)
             uid_seen[lbl] = id(obj)
     recursive_foreach(cake, check_ids)
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='gemd',
-      version='0.9.r32',
+      version='0.9.3',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='gemd',
-      version='0.9.2',
+      version='0.9.r32',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='gemd',
-      version='0.9.3',
+      version='0.11.0',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',


### PR DESCRIPTION
This edit of the Cake demo includes several changes reflecting shifting understanding since it was first generated:

* Template scope is now explicitly defined
* A mixer speed Attribute Template is used to create several Process Spec Parameters that have no Run equivalent
* Spec construction is now done via a local method to remove redundant strings
* Many tags and notes were added
* Ingredient names were brought into better alignment with best practice, as well as adding `allowed_names` values to Process Templates
* Fake brand names are added to Material Runs, as opposed to their abstract Spec counterparts
* An argument for defining a FileLink for an image to be attached to the Baked Doneness measurement was added