### PR TITLE
Bugfixes for cake demo

### DIFF
--- a/gemd/demo/cake.py
+++ b/gemd/demo/cake.py
@@ -222,7 +222,7 @@ def make_cake_templates():
     )
 
     for key in tmpl:
-        tmpl[key].add_uid(TEMPLATE_SCOPE, key)
+        tmpl[key].add_uid(TEMPLATE_SCOPE, key.lower().replace(' ', '-'))
     return tmpl
 
 
@@ -233,21 +233,27 @@ def make_cake_spec(tmpl=None):
     if tmpl is None:
         tmpl = make_cake_templates()
 
-    def _make_ingredient(material, **kwargs):
+    def _make_ingredient(*, material, process, **kwargs):
         """Convenience method to utilize material fields in creating an ingredient's arguments."""
         return IngredientSpec(
             name=material.name.lower(),
             tags=list(material.tags),
             material=material,
+            process=process,
+            uids={DEMO_SCOPE: "{}--{}".format(material.uids[DEMO_SCOPE], process.uids[DEMO_SCOPE])},
             **kwargs
         )
 
-    def _make_material(material_name, process_tmpl_name, process_kwargs, **material_kwargs):
+    def _make_material(material_name, template, process_tmpl_name, process_kwargs, **material_kwargs):
         """Convenience method to reuse material name in creating a material's arguments."""
+        process_name = "{} {}".format(process_tmpl_name, material_name)
         return MaterialSpec(
             name=material_name,
+            uids={DEMO_SCOPE: material_name.lower().replace(' ', '-')},
+            template=template,
             process=ProcessSpec(
-                name="{} {}".format(process_tmpl_name, material_name),
+                name=process_name,
+                uids={DEMO_SCOPE: process_name.lower().replace(' ', '-')},
                 template=tmpl[process_tmpl_name],
                 **process_kwargs
             ),
@@ -624,6 +630,7 @@ def make_cake_spec(tmpl=None):
     _make_ingredient(
         material=eggs,
         labels=['wet'],
+        process=wetmix.process,
         absolute_quantity=NominalReal(nominal=4, units='')
     )
 
@@ -741,25 +748,6 @@ def make_cake_spec(tmpl=None):
         mass_fraction=NominalReal(nominal=0.6387, units='')  # 4 c @ 30 g/ 0.25 cups
     )
 
-    # Crawl tree and annotate with uids; only add ids if there's nothing there
-    def _make_fuzzer():
-        """Generate closure that knows if it's seen a given name."""
-        seen = set()
-
-        def _fuzz_func(obj):
-            """Add fuzz to name in ID as necessary."""
-            name = 'ing-' if isinstance(obj, IngredientSpec) else ''
-            name += obj.name
-            while name.lower() in seen:
-                name += '-again'
-            seen.add(name.lower())
-            return name
-
-        return _fuzz_func
-
-    _name_fuzz = _make_fuzzer()
-    recursive_foreach(cake, lambda obj: obj.uids or obj.add_uid(DEMO_SCOPE, _name_fuzz(obj)))
-
     return cake
 
 
@@ -770,6 +758,13 @@ def make_cake(seed=None, tmpl=None, cake_spec=None, toothpick_img=None):
 
     if seed is not None:
         random.seed(seed)
+    # Code to generate quasi-repeatable run annotations
+    # Note there are potential machine dependencies
+    md5 = hashlib.md5()
+    for x in random.getstate()[1]:
+        md5.update(struct.pack(">I", x))
+    run_key = md5.hexdigest()
+
     ######################################################################
     # Parent Objects
     if tmpl is None:
@@ -789,6 +784,7 @@ def make_cake(seed=None, tmpl=None, cake_spec=None, toothpick_img=None):
     queue = [cake]
     while queue:
         item = queue.pop(0)
+        item.add_uid(DEMO_SCOPE, '{}-{}'.format(item.spec.uids[DEMO_SCOPE], run_key))
         if item.spec.tags is not None:
             item.tags = list(item.spec.tags)
         if item.spec.notes:  # Neither None or empty string
@@ -882,9 +878,14 @@ def make_cake(seed=None, tmpl=None, cake_spec=None, toothpick_img=None):
                                         )
     sugar_content.spec = salt_content.spec
 
+    # Note that while specs are regenerated each make_cake invocation, they are all identical
     for msr in (cake_taste, cake_appearance, frosting_taste, frosting_sweetness,
                 baked_doneness, flour_content, salt_content, sugar_content):
-        msr.spec.add_uid(DEMO_SCOPE, msr.spec.name)
+        msr.spec.add_uid(DEMO_SCOPE, msr.spec.name.lower())
+        msr.add_uid(DEMO_SCOPE, '{}--{}-{}'.format(msr.spec.uids[DEMO_SCOPE],
+                                                   msr.material.spec.uids[DEMO_SCOPE],
+                                                   run_key
+                                                   ))
 
     ######################################################################
     # Let's add some attributes
@@ -1028,35 +1029,6 @@ def make_cake(seed=None, tmpl=None, cake_spec=None, toothpick_img=None):
         template=tmpl["Expected Sample Mass"],
         origin="specified"
     ))
-
-    # Code to generate quasi-repeatable run annotations
-    # Note there are potential machine dependencies
-    md5 = hashlib.md5()
-    for x in random.getstate()[1]:
-        md5.update(struct.pack(">I", x))
-    run_key = md5.hexdigest()
-
-    # Crawl tree and annotate with uids; only add ids if there's nothing there
-    def _make_disambiguator():
-        """Generate a closure to post-annotate for disambiguation."""
-        count = dict()
-
-        def _disambiguator(name):
-            """Add a number to the name if you've seen it more than once."""
-            if name in count:
-                count[name] = count[name] + 1
-                return "{}-{}".format(name, count[name])
-            else:
-                count[name] = 1
-                return name
-
-        return _disambiguator
-
-    _disambig = _make_disambiguator()
-    recursive_foreach(
-        cake,
-        lambda obj: obj.uids or obj.add_uid(DEMO_SCOPE, _disambig(obj.name) + run_key)
-    )
 
     cake.notes = cake.notes + "; Très délicieux! 😀"
     cake.file_links = [FileLink(

--- a/gemd/demo/tests/test_cake.py
+++ b/gemd/demo/tests/test_cake.py
@@ -9,29 +9,15 @@ from gemd.entity.object.ingredient_spec import IngredientSpec
 from gemd.entity.object.ingredient_run import IngredientRun
 from gemd.entity.file_link import FileLink
 
-from gemd.json import dumps, loads
+from gemd.json import dumps
 from gemd.demo.cake import make_cake_templates, make_cake_spec, make_cake, \
     import_toothpick_picture, change_scope
 from gemd.util import recursive_foreach
-from gemd.entity.util import complete_material_history
 
 
 def test_cake():
     """Create cake, serialize, deserialize."""
     cake = make_cake(seed=42)
-
-    def test_for_loss(obj):
-        assert(obj == loads(dumps(obj)))
-    recursive_foreach(cake, test_for_loss)
-
-    # And verify equality was working in the first place
-    cake2 = loads(dumps(cake))
-    cake2.name = "It's a trap!"
-    assert(cake2 != cake)
-    cake2.name = cake.name
-    assert(cake == cake2)
-    cake2.uids['new'] = "It's a trap!"
-    assert(cake2 != cake)
 
     # Check that all the objects show up
     tot_count = 0
@@ -41,11 +27,6 @@ def test_cake():
         tot_count += 1
 
     recursive_foreach(cake, increment)
-    assert tot_count == 139
-
-    # And make sure nothing was lost
-    tot_count = 0
-    recursive_foreach(loads(dumps(complete_material_history(cake))), increment)
     assert tot_count == 139
 
     # Check that no UIDs collide

--- a/gemd/demo/tests/test_cake.py
+++ b/gemd/demo/tests/test_cake.py
@@ -41,12 +41,12 @@ def test_cake():
         tot_count += 1
 
     recursive_foreach(cake, increment)
-    assert tot_count == 133
+    assert tot_count == 139
 
     # And make sure nothing was lost
     tot_count = 0
     recursive_foreach(loads(dumps(complete_material_history(cake))), increment)
-    assert tot_count == 133
+    assert tot_count == 139
 
     # Check that no UIDs collide
     uid_seen = dict()

--- a/gemd/entity/value/nominal_integer.py
+++ b/gemd/entity/value/nominal_integer.py
@@ -27,6 +27,8 @@ class NominalInteger(IntegerValue):
     @nominal.setter
     def nominal(self, nominal: int) -> None:
         """A proscribed integer value without uncertainty."""
-        # This check is necessary to handle JSON serialization behavior under 3.5
-        assert float(int(nominal)) == float(nominal), "nominal value must be an int"
+        # This check/cast is necessary to handle JSON serialization behavior under 3.6
+        if not isinstance(nominal, (int, float)) or int(nominal) != nominal:
+            raise TypeError("nominal must be an int; got an {}({})".format(type(nominal), nominal))
+
         self._nominal = int(nominal)

--- a/gemd/entity/value/nominal_integer.py
+++ b/gemd/entity/value/nominal_integer.py
@@ -15,7 +15,18 @@ class NominalInteger(IntegerValue):
 
     typ = "nominal_integer"
 
-    def __init__(self, nominal=None):
-        assert isinstance(nominal, int), \
-            "nominal value must be an int"
+    def __init__(self, nominal):
+        self._nominal = None
         self.nominal = nominal
+
+    @property
+    def nominal(self) -> int:
+        """A proscribed integer value without uncertainty."""
+        return int(self._nominal)
+
+    @nominal.setter
+    def nominal(self, nominal: int) -> None:
+        """A proscribed integer value without uncertainty."""
+        # This check is necessary to handle JSON serialization behavior under 3.5
+        assert float(int(nominal)) == float(nominal), "nominal value must be an int"
+        self._nominal = int(nominal)

--- a/gemd/entity/value/tests/test_nomial_integer.py
+++ b/gemd/entity/value/tests/test_nomial_integer.py
@@ -1,0 +1,12 @@
+"""Tests of the UniformInteger class."""
+import pytest
+
+from gemd.entity.value.nominal_integer import NominalInteger
+
+
+def test_bounds_are_integers():
+    """Value must be an integer."""
+    with pytest.raises(AssertionError):
+        NominalInteger(5.7)
+    with pytest.raises(ValueError):
+        NominalInteger("five")

--- a/gemd/entity/value/tests/test_nomial_integer.py
+++ b/gemd/entity/value/tests/test_nomial_integer.py
@@ -6,7 +6,8 @@ from gemd.entity.value.nominal_integer import NominalInteger
 
 def test_bounds_are_integers():
     """Value must be an integer."""
-    with pytest.raises(AssertionError):
+    NominalInteger(5)
+    with pytest.raises(TypeError):
         NominalInteger(5.7)
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         NominalInteger("five")

--- a/gemd/entity/value/tests/test_uniform_integer.py
+++ b/gemd/entity/value/tests/test_uniform_integer.py
@@ -8,13 +8,17 @@ def test_bounds_order():
     """Lower bound must be <= upper bound."""
     UniformInteger(3, 7)
     UniformInteger(12, 12)
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         UniformInteger(22, 18)
+    with pytest.raises(ValueError):
+        UniformInteger(3, 7).lower_bound = 10
+    with pytest.raises(ValueError):
+        UniformInteger(3, 7).upper_bound = 1
 
 
 def test_bounds_are_integers():
     """Lower bound and upper bound must be integers."""
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         UniformInteger(5.7, 10)
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         UniformInteger(1, "five")

--- a/gemd/entity/value/tests/test_uniform_integer.py
+++ b/gemd/entity/value/tests/test_uniform_integer.py
@@ -16,5 +16,5 @@ def test_bounds_are_integers():
     """Lower bound and upper bound must be integers."""
     with pytest.raises(AssertionError):
         UniformInteger(5.7, 10)
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         UniformInteger(1, "five")

--- a/gemd/entity/value/uniform_integer.py
+++ b/gemd/entity/value/uniform_integer.py
@@ -38,7 +38,9 @@ class UniformInteger(IntegerValue):
                 "lower_bound must be an int; got {}({})".format(type(lower_bound), lower_bound))
         if self._upper_bound is not None:
             if lower_bound > self.upper_bound:
-                raise ValueError("lower_bound ({}) must be <= upper_bound ({})".format(lower_bound, self.upper_bound))
+                raise ValueError(
+                    "lower_bound ({}) must be <= upper_bound ({})".format(lower_bound,
+                                                                          self.upper_bound))
         self._lower_bound = int(lower_bound)
 
     @property
@@ -54,5 +56,7 @@ class UniformInteger(IntegerValue):
             raise TypeError(
                 "upper_bound must be an int; got {}({})".format(type(upper_bound), upper_bound))
         if self.lower_bound > upper_bound:
-            raise ValueError("upper_bound ({}) must be >= lower_bound ({})".format(upper_bound, self.lower_bound))
+            raise ValueError(
+                "upper_bound ({}) must be >= lower_bound ({})".format(upper_bound,
+                                                                      self.lower_bound))
         self._upper_bound = int(upper_bound)

--- a/gemd/entity/value/uniform_integer.py
+++ b/gemd/entity/value/uniform_integer.py
@@ -17,10 +17,35 @@ class UniformInteger(IntegerValue):
 
     typ = "uniform_integer"
 
-    def __init__(self, lower_bound=None, upper_bound=None):
-        assert isinstance(lower_bound, int)
-        assert isinstance(upper_bound, int)
-        assert lower_bound <= upper_bound, \
-            "the lower bound must be <= the upper bound"
+    def __init__(self, lower_bound: int, upper_bound: int):
+        self._lower_bound = None
+        self._upper_bound = None
+
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
+        assert self.lower_bound <= self.upper_bound, \
+            "the lower bound must be <= the upper bound"
+
+    @property
+    def lower_bound(self) -> int:
+        """The lower bound of a uniform distribution."""
+        return int(self._lower_bound)
+
+    @lower_bound.setter
+    def lower_bound(self, lower_bound: int) -> None:
+        """The lower bound of a uniform distribution."""
+        # This check is necessary to handle JSON serialization behavior under 3.5
+        assert float(int(lower_bound)) == float(lower_bound), "lower bound must be an int"
+        self._lower_bound = int(lower_bound)
+
+    @property
+    def upper_bound(self) -> int:
+        """The upper bound of a uniform distribution."""
+        return int(self._upper_bound)
+
+    @upper_bound.setter
+    def upper_bound(self, upper_bound: int) -> None:
+        """The upper bound of a uniform distribution."""
+        # This check is necessary to handle JSON serialization behavior under 3.5
+        assert float(int(upper_bound)) == float(upper_bound), "upper bound must be an int"
+        self._upper_bound = int(upper_bound)

--- a/gemd/entity/value/uniform_integer.py
+++ b/gemd/entity/value/uniform_integer.py
@@ -23,8 +23,6 @@ class UniformInteger(IntegerValue):
 
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
-        assert self.lower_bound <= self.upper_bound, \
-            "the lower bound must be <= the upper bound"
 
     @property
     def lower_bound(self) -> int:
@@ -34,8 +32,13 @@ class UniformInteger(IntegerValue):
     @lower_bound.setter
     def lower_bound(self, lower_bound: int) -> None:
         """The lower bound of a uniform distribution."""
-        # This check is necessary to handle JSON serialization behavior under 3.5
-        assert float(int(lower_bound)) == float(lower_bound), "lower bound must be an int"
+        # This check/cast is necessary to handle JSON serialization behavior under 3.6
+        if not isinstance(lower_bound, (int, float)) or int(lower_bound) != lower_bound:
+            raise TypeError(
+                "lower_bound must be an int; got {}({})".format(type(lower_bound), lower_bound))
+        if self._upper_bound is not None:
+            if lower_bound > self.upper_bound:
+                raise ValueError("lower_bound ({}) must be <= upper_bound ({})".format(lower_bound, self.upper_bound))
         self._lower_bound = int(lower_bound)
 
     @property
@@ -46,6 +49,10 @@ class UniformInteger(IntegerValue):
     @upper_bound.setter
     def upper_bound(self, upper_bound: int) -> None:
         """The upper bound of a uniform distribution."""
-        # This check is necessary to handle JSON serialization behavior under 3.5
-        assert float(int(upper_bound)) == float(upper_bound), "upper bound must be an int"
+        # This check/cast is necessary to handle JSON serialization behavior under 3.6
+        if not isinstance(upper_bound, (int, float)) or int(upper_bound) != upper_bound:
+            raise TypeError(
+                "upper_bound must be an int; got {}({})".format(type(upper_bound), upper_bound))
+        if self.lower_bound > upper_bound:
+            raise ValueError("upper_bound ({}) must be >= lower_bound ({})".format(upper_bound, self.lower_bound))
         self._upper_bound = int(upper_bound)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='gemd',
-      version='0.11.0',
+      version='0.11.1',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',


### PR DESCRIPTION
This PR addresses several issues:
* There were UIDs that collided when compared as lower() strings.  The algorithm for generating UIDs was reworked so that should no longer be any collisions.
* The test suite was modified to catch this.
* There was a linking failure in the ingredient set.  This bug was corrected and is now guarded against through the _make_ingredient sig
