### PR TITLE
Make names & labels dynamic

### DIFF
--- a/gemd/entity/object/ingredient_run.py
+++ b/gemd/entity/object/ingredient_run.py
@@ -73,9 +73,7 @@ class IngredientRun(BaseObject, HasQuantities):
         """Get name."""
         from gemd.entity.object.ingredient_spec import IngredientSpec
         if isinstance(self.spec, IngredientSpec):
-            name = self.spec.name
-            self.__class__._name_setter(self, name)
-            return name
+            return self.spec.name
         else:
             return super().name
 
@@ -98,9 +96,7 @@ class IngredientRun(BaseObject, HasQuantities):
         """Get labels."""
         from gemd.entity.object.ingredient_spec import IngredientSpec
         if isinstance(self.spec, IngredientSpec):
-            labels = self.spec.labels
-            self.__class__._labels_setter(self, labels)
-            return labels
+            return self.spec.labels
         else:
             return self._labels
 
@@ -176,9 +172,6 @@ class IngredientRun(BaseObject, HasQuantities):
             self._spec = None
         elif isinstance(spec, (IngredientSpec, LinkByUID)):
             self._spec = spec
-            if isinstance(spec, IngredientSpec):  # Update values
-                self.__class__._labels_setter(self, spec.labels)
-                self.__class__._name_setter(self, spec.name)
         else:
             raise TypeError("spec must be a IngredientSpec or LinkByUID: {}".format(spec))
 

--- a/gemd/entity/object/ingredient_run.py
+++ b/gemd/entity/object/ingredient_run.py
@@ -71,7 +71,13 @@ class IngredientRun(BaseObject, HasQuantities):
     @property
     def name(self):
         """Get name."""
-        return super().name
+        from gemd.entity.object.ingredient_spec import IngredientSpec
+        if isinstance(self.spec, IngredientSpec):
+            name = self.spec.name
+            self.__class__._name_setter(self, name)
+            return name
+        else:
+            return super().name
 
     @name.setter
     def name(self, name):
@@ -90,7 +96,13 @@ class IngredientRun(BaseObject, HasQuantities):
     @property
     def labels(self):
         """Get labels."""
-        return self._labels
+        from gemd.entity.object.ingredient_spec import IngredientSpec
+        if isinstance(self.spec, IngredientSpec):
+            labels = self.spec.labels
+            self.__class__._labels_setter(self, labels)
+            return labels
+        else:
+            return self._labels
 
     @labels.setter
     @deprecation.deprecated(deprecated_in="0.12", removed_in="0.13",
@@ -155,11 +167,16 @@ class IngredientRun(BaseObject, HasQuantities):
     def spec(self, spec):
         from gemd.entity.object.ingredient_spec import IngredientSpec
         from gemd.entity.link_by_uid import LinkByUID
+
+        if isinstance(self._spec, IngredientSpec):  # Store values if you had them
+            self.__class__._labels_setter(self, self.spec.labels)
+            self.__class__._name_setter(self, self.spec.name)
+
         if spec is None:
             self._spec = None
         elif isinstance(spec, (IngredientSpec, LinkByUID)):
             self._spec = spec
-            if isinstance(spec, IngredientSpec):
+            if isinstance(spec, IngredientSpec):  # Update values
                 self.__class__._labels_setter(self, spec.labels)
                 self.__class__._name_setter(self, spec.name)
         else:

--- a/gemd/entity/object/tests/test_ingredient_run.py
+++ b/gemd/entity/object/tests/test_ingredient_run.py
@@ -57,6 +57,13 @@ def test_name_persistance():
                         process=pr_link, material=mr_link)
     assert run.name == spec.name
     assert run.labels == spec.labels
+
+    # Try changing them and make sure they change
+    spec.name = 'Frank'
+    spec.labels = ['other', 'words']
+    assert run.name == spec.name
+    assert run.labels == spec.labels
+
     run.spec = LinkByUID(scope='local', id='ing_spec')
     # Name and labels are now stashed but not stored
     assert run == je.copy(run)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='gemd',
-      version='0.12.0',
+      version='0.12.1',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',


### PR DESCRIPTION
#### Bugfix
Because assignment of names and labels for Ingredient Runs were cached at the time of setting the Ingredient Spec, they could get out of sync.  This explicitly pulls the values from the spec when it is present and only caches the value when the spec is changed.