### PR TITLE
Added scope accessors to cake demo

### DIFF
--- a/gemd/demo/cake.py
+++ b/gemd/demo/cake.py
@@ -51,6 +51,16 @@ def change_scope(data, *, templates=None):
         TEMPLATE_SCOPE = templates
 
 
+def get_demo_scope():
+    """Return the value of the DEMO_SCOPE variable."""
+    return DEMO_SCOPE
+
+
+def get_template_scope():
+    """Return the value of the DEMO_SCOPE variable."""
+    return TEMPLATE_SCOPE
+
+
 def import_toothpick_picture():
     """Return the stream of the toothpick picture."""
     import pkg_resources

--- a/gemd/demo/tests/test_cake.py
+++ b/gemd/demo/tests/test_cake.py
@@ -11,7 +11,7 @@ from gemd.entity.file_link import FileLink
 
 from gemd.json import dumps
 from gemd.demo.cake import make_cake_templates, make_cake_spec, make_cake, \
-    import_toothpick_picture, change_scope
+    import_toothpick_picture, change_scope, get_demo_scope, get_template_scope
 from gemd.util import recursive_foreach
 
 
@@ -97,9 +97,13 @@ def test_scope():
     """Make sure change scope does what we want it to."""
     default_cake = make_cake()
     default_scope = next(iter(default_cake.uids))
+
     change_scope('second-scope')
     second_cake = make_cake()
+
     change_scope(data='third-scope', templates='also-a-scope')
+    assert get_demo_scope() == 'third-scope'
+    assert get_template_scope() == 'also-a-scope'
     third_cake = make_cake()
 
     assert 'second-scope' not in default_cake.uids

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='gemd',
-      version='0.13.1',
+      version='0.14.0',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',


### PR DESCRIPTION
Added methods to cake demo to return scopes, instead of relying on importing package variables.  Tests have been augmented for 100 % coverage.