### PR TITLE
Make CaseInsensitiveDict delete obsolete keys

### DIFF
--- a/gemd/entity/case_insensitive_dict.py
+++ b/gemd/entity/case_insensitive_dict.py
@@ -108,8 +108,6 @@ class CaseInsensitiveDict(dict):
         """
         Remove and return a (key, value) pair from the dictionary.
 
-        Pairs are returned in LIFO order.
-
         popitem() is useful to destructively iterate over a dictionary, as often used
         in set algorithms.  If the dictionary is empty, calling popitem() raises a
         KeyError.

--- a/gemd/entity/case_insensitive_dict.py
+++ b/gemd/entity/case_insensitive_dict.py
@@ -159,6 +159,9 @@ class CaseInsensitiveDict(dict):
         """
         if mapping is None:
             mapping = dict()
+            no_mapping = True
+        else:
+            no_mapping = False
         for key in list(mapping.keys()) + list(kwargs.keys()):
             if key.lower() in self.lowercase_dict:
                 prev = self.lowercase_dict[key.lower()]
@@ -166,7 +169,7 @@ class CaseInsensitiveDict(dict):
                     raise ValueError(
                         "Key '{}' already exists in dict with different case: "
                         "'{}'".format(key, prev))
-        if mapping is None:
+        if no_mapping:
             super().update(**kwargs)
         else:
             super().update(mapping, **kwargs)

--- a/gemd/entity/case_insensitive_dict.py
+++ b/gemd/entity/case_insensitive_dict.py
@@ -1,6 +1,6 @@
-from typing import Tuple
+from typing import Tuple, Sequence, Any, Mapping, Optional
 
-_RaiseKeyError = object() # singleton for no-default behavior
+_RaiseKeyError = object()  # singleton for no-default behavior
 
 
 class CaseInsensitiveDict(dict):
@@ -22,16 +22,16 @@ class CaseInsensitiveDict(dict):
 
     """
 
-    def __init__(self, seq=None, **kwargs):
+    def __init__(self, seq: Sequence = None, **kwargs) -> None:
         super().__init__(seq or {}, **kwargs)
         self.lowercase_dict = {}
         for key in self:
             self._register_key(key)
 
-    def __getitem__(self, key: str):
+    def __getitem__(self, key: str) -> Any:
         return super().__getitem__(self.lowercase_dict[key.lower()])
 
-    def get(self, key: str, default=None):
+    def get(self, key: str, default: Any = None) -> Any:
         """
         Get the value for a given case-insensitive key.
 
@@ -55,22 +55,45 @@ class CaseInsensitiveDict(dict):
         else:
             return default
 
-    def __setitem__(self, key: str, value):
+    def __setitem__(self, key: str, value: Any) -> None:
         self._register_key(key)
         super().__setitem__(key, value)
 
-    def __contains__(self, key: str):
+    def __contains__(self, key: str) -> bool:
         return self.lowercase_dict.__contains__(key.lower())
 
-    def __delitem__(self, key):
+    def __delitem__(self, key) -> None:
+        key = self.lowercase_dict.get(key.lower(), key)
         super().__delitem__(key)
         del self.lowercase_dict[key.lower()]
 
     def clear(self) -> None:
+        """Remove all items from the dictionary."""
         super().clear()
         self.lowercase_dict.clear()
 
-    def pop(self, key: str, default=_RaiseKeyError):
+    def pop(self, key: str, default=_RaiseKeyError) -> Any:
+        """
+        Remove and return the value for a given key from the dictionary.
+
+        If key is in the dictionary, remove it and return its value, else return default.
+        If default is not given and key is not in the dictionary, a KeyError is raised.
+
+        Parameters
+        ----------
+        key: str
+            The key to look up (possibly with a different casing).
+
+        default: Any
+            The result to return if the key is not present.
+
+        Returns
+        -------
+        Any
+            The value associated with the case-insensitive version of `key`, or None
+            if `key` is not present.
+
+        """
         if default is _RaiseKeyError:
             if key not in self:
                 raise KeyError(key)
@@ -82,14 +105,75 @@ class CaseInsensitiveDict(dict):
         return val
 
     def popitem(self) -> Tuple:
+        """
+        Remove and return a (key, value) pair from the dictionary.
+
+        Pairs are returned in LIFO order.
+
+        popitem() is useful to destructively iterate over a dictionary, as often used
+        in set algorithms.  If the dictionary is empty, calling popitem() raises a
+        KeyError.
+
+        Changed in version 3.7: LIFO order is now guaranteed. In prior versions,
+        popitem() would return an arbitrary key/value pair.
+
+        Returns
+        -------
+        Tuple(str, Any)
+            The key-value pair
+
+        """
         result = super().popitem()
         del self.lowercase_dict[result[0].lower()]
         return result
-        
+
     def copy(self) -> 'CaseInsensitiveDict':
+        """
+        Return a shallow copy of the dictionary.
+
+        Returns
+        -------
+        CaseInsensitiveDict
+            A duplicate of the dictionary
+
+        """
         return CaseInsensitiveDict(super().copy())
 
-    def _register_key(self, key: str):
+    def update(self, mapping: Optional[Mapping[str, Any]] = None, **kwargs) -> None:
+        """
+        Update the dictionary with the key/value pairs from other, overwriting existing keys.
+
+        update() accepts either another dictionary object or an iterable of
+        key/value pairs (as tuples or other iterables of length two). If keyword
+        arguments are specified, the dictionary is then updated with those
+        key/value pairs: d.update(red=1, blue=2).
+
+        Parameters
+        ----------
+        mapping: Mapping
+            The set of (key, value) pairs to store
+
+        kwargs: (str, Any)
+            Alternatively, the set of keyword arguments
+
+        """
+        if mapping is None:
+            mapping = dict()
+        for key in list(mapping.keys()) + list(kwargs.keys()):
+            if key.lower() in self.lowercase_dict:
+                prev = self.lowercase_dict[key.lower()]
+                if prev != key:
+                    raise ValueError(
+                        "Key '{}' already exists in dict with different case: "
+                        "'{}'".format(key, prev))
+        if mapping is None:
+            super().update(**kwargs)
+        else:
+            super().update(mapping, **kwargs)
+        for key in list(mapping.keys()) + list(kwargs.keys()):
+            self._register_key(key)
+
+    def _register_key(self, key: str) -> None:
         """
         Register a key to the dictionary.
 

--- a/gemd/entity/case_insensitive_dict.py
+++ b/gemd/entity/case_insensitive_dict.py
@@ -1,3 +1,8 @@
+from typing import Tuple
+
+_RaiseKeyError = object() # singleton for no-default behavior
+
+
 class CaseInsensitiveDict(dict):
     """
     A dictionary in which the keys are case-insensitive.
@@ -56,6 +61,33 @@ class CaseInsensitiveDict(dict):
 
     def __contains__(self, key: str):
         return self.lowercase_dict.__contains__(key.lower())
+
+    def __delitem__(self, key):
+        super().__delitem__(key)
+        del self.lowercase_dict[key.lower()]
+
+    def clear(self) -> None:
+        super().clear()
+        self.lowercase_dict.clear()
+
+    def pop(self, key: str, default=_RaiseKeyError):
+        if default is _RaiseKeyError:
+            if key not in self:
+                raise KeyError(key)
+            val = super().pop(self.lowercase_dict[key.lower()])
+        else:
+            val = super().pop(self.lowercase_dict.get(key.lower()), default)
+        if key in self:
+            del self.lowercase_dict[key.lower()]
+        return val
+
+    def popitem(self) -> Tuple:
+        result = super().popitem()
+        del self.lowercase_dict[result[0].lower()]
+        return result
+        
+    def copy(self) -> 'CaseInsensitiveDict':
+        return CaseInsensitiveDict(super().copy())
 
     def _register_key(self, key: str):
         """

--- a/gemd/entity/tests/test_case_insensitive_dict.py
+++ b/gemd/entity/tests/test_case_insensitive_dict.py
@@ -60,7 +60,7 @@ def test_contains():
 
 def test_full_api():
     """Tests checking consistency of all standard dictionary methods."""
-    data = {'K'+x: 'V'+x for x in ('1', '2', '3', '4', '5')}
+    data = {'K' + x: 'V' + x for x in ('1', '2', '3', '4', '5')}
     ci_dict = CaseInsensitiveDict(**data)
 
     assert sorted(list(ci_dict)) == sorted(list(data))
@@ -99,4 +99,8 @@ def test_full_api():
     assert ci_dict.setdefault(pop_k.upper(), pop_v.upper()) == pop_v.upper()
     assert ci_dict.setdefault(pop_k.upper(), pop_v.lower()) == pop_v.upper()
     ci_dict.update({pop_k.upper(): pop_v.lower(), 'K6': 'v6'})
+    with pytest.raises(ValueError):
+        ci_dict.update(k6='v6')
+    with pytest.raises(ValueError):
+        ci_dict.update({k.lower(): v for k, v in ci_dict.items()})
     assert 'v6' in ci_dict.values()

--- a/gemd/entity/tests/test_case_insensitive_dict.py
+++ b/gemd/entity/tests/test_case_insensitive_dict.py
@@ -58,49 +58,81 @@ def test_contains():
     assert 'not_a_key' not in data_dict
 
 
-def test_full_api():
+def test_all_dict_methods():
     """Tests checking consistency of all standard dictionary methods."""
+    # __init__
     data = {'K' + x: 'V' + x for x in ('1', '2', '3', '4', '5')}
     ci_dict = CaseInsensitiveDict(**data)
 
     assert sorted(list(ci_dict)) == sorted(list(data))
     assert len(ci_dict) == len(data)
+
+    # __getitem__
     assert ci_dict['K1'] == data['K1']
+
+    # __setitem__
     ci_dict['K6'] = 'V6'
     assert ci_dict['K6'] == 'V6'
+
+    # __delitem__
     del ci_dict['K6']
     assert 'K6' not in ci_dict
+
+    # iter(d)
     ci_iter = iter(ci_dict)
     for k in ci_iter:
         assert k in data
+
+    # clear
     ci_dict.clear()
     assert len(ci_dict) == 0
     assert len(ci_dict.lowercase_dict) == 0
     for k, v in data.items():
         ci_dict[k.lower()] = v.lower()
+
+    # copy
     dup = ci_dict.copy()
     assert type(dup) == type(ci_dict)
+
+    # fromkeys
     key_copy = CaseInsensitiveDict.fromkeys(dup)
     assert set(dup) == set(key_copy)
     assert type(dup) == type(key_copy)
+
+    # get
     assert ci_dict.get('K1') == 'v1'
     assert ci_dict.get('K6', None) is None
+
+    # items
     for k, v in ci_dict.items():
         assert data[k.upper()] == v.upper()
+
+    # keys
     for k in ci_dict.keys():
         assert k not in data  # because the cases are all wrong
+
+    # pop
     assert ci_dict.pop('k1') == 'v1'
     assert 'K1' not in ci_dict
     with pytest.raises(KeyError):
         ci_dict.pop('k1')
     assert ci_dict.pop('k1', None) is None
+
+    # popitem
     pop_k, pop_v = ci_dict.popitem()
     assert pop_k not in ci_dict
+
+    # setdefault
     assert ci_dict.setdefault(pop_k.upper(), pop_v.upper()) == pop_v.upper()
     assert ci_dict.setdefault(pop_k.upper(), pop_v.lower()) == pop_v.upper()
+
+    # update
     ci_dict.update({pop_k.upper(): pop_v.lower(), 'K6': 'v6'})
+    ci_dict.update(K6='V6')
     with pytest.raises(ValueError):
         ci_dict.update(k6='v6')
     with pytest.raises(ValueError):
         ci_dict.update({k.lower(): v for k, v in ci_dict.items()})
-    assert 'v6' in ci_dict.values()
+
+    # values
+    assert 'V6' in ci_dict.values()

--- a/gemd/entity/tests/test_case_insensitive_dict.py
+++ b/gemd/entity/tests/test_case_insensitive_dict.py
@@ -56,3 +56,46 @@ def test_contains():
         assert k in data_dict
 
     assert 'not_a_key' not in data_dict
+
+
+def test_full_api():
+    """Tests checking consistency of all standard dictionary methods."""
+    data = {'K'+x: 'V'+x for x in ('1', '2', '3', '4', '5')}
+    ci_dict = CaseInsensitiveDict(**data)
+
+    assert sorted(list(ci_dict)) == sorted(list(data))
+    assert len(ci_dict) == len(data)
+    assert ci_dict['K1'] == data['K1']
+    ci_dict['K6'] = 'V6'
+    assert ci_dict['K6'] == 'V6'
+    del ci_dict['K6']
+    assert 'K6' not in ci_dict
+    ci_iter = iter(ci_dict)
+    for k in ci_iter:
+        assert k in data
+    ci_dict.clear()
+    assert len(ci_dict) == 0
+    for k, v in data.items():
+        ci_dict[k.lower()] = v.lower()
+    dup = ci_dict.copy()
+    assert type(dup) == type(ci_dict)
+    key_copy = CaseInsensitiveDict.fromkeys(dup)
+    assert set(dup) == set(key_copy)
+    assert type(dup) == type(key_copy)
+    assert ci_dict.get('K1') == 'v1'
+    assert ci_dict.get('K6', None) is None
+    for k, v in ci_dict.items():
+        assert data[k.upper()] == v.lower()
+    for k in ci_dict.keys():
+        assert k not in data  # because the cases are all wrong
+    assert ci_dict.pop('K1') == 'v1'
+    assert 'K1' not in ci_dict
+    with pytest.raises(KeyError):
+        ci_dict.pop('K1')
+    assert ci_dict.pop('K1', None) is None
+    pop_k, pop_v = ci_dict.popitem()
+    assert pop_k not in ci_dict
+    assert ci_dict.setdefault(pop_k.upper(), pop_v.upper()) == pop_v.upper()
+    assert ci_dict.setdefault(pop_k.upper(), pop_v.lower()) == pop_v.upper()
+    ci_dict.update({pop_k.upper(): pop_v.lower(), 'K6': 'v6'})
+    assert 'v6' in ci_dict.values()

--- a/gemd/entity/tests/test_case_insensitive_dict.py
+++ b/gemd/entity/tests/test_case_insensitive_dict.py
@@ -75,6 +75,7 @@ def test_full_api():
         assert k in data
     ci_dict.clear()
     assert len(ci_dict) == 0
+    assert len(ci_dict.lowercase_dict) == 0
     for k, v in data.items():
         ci_dict[k.lower()] = v.lower()
     dup = ci_dict.copy()
@@ -85,14 +86,14 @@ def test_full_api():
     assert ci_dict.get('K1') == 'v1'
     assert ci_dict.get('K6', None) is None
     for k, v in ci_dict.items():
-        assert data[k.upper()] == v.lower()
+        assert data[k.upper()] == v.upper()
     for k in ci_dict.keys():
         assert k not in data  # because the cases are all wrong
-    assert ci_dict.pop('K1') == 'v1'
+    assert ci_dict.pop('k1') == 'v1'
     assert 'K1' not in ci_dict
     with pytest.raises(KeyError):
-        ci_dict.pop('K1')
-    assert ci_dict.pop('K1', None) is None
+        ci_dict.pop('k1')
+    assert ci_dict.pop('k1', None) is None
     pop_k, pop_v = ci_dict.popitem()
     assert pop_k not in ci_dict
     assert ci_dict.setdefault(pop_k.upper(), pop_v.upper()) == pop_v.upper()

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='gemd',
-      version='0.14.0',
+      version='0.14.1',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',


### PR DESCRIPTION
This is a bug fix to address issues where a key would be remembered by CaseInsensitiveDict even after the key had been deleted from the dictionary.  It generally follows the principle that a set operation requires using the exact key whereas a get or a delete should be forgiving of case inconsistencies.