### PR TITLE
Modify Strehlow & Cook to have heterogeneous units

### DIFF
--- a/gemd/demo/strehlow_and_cook.py
+++ b/gemd/demo/strehlow_and_cook.py
@@ -28,6 +28,7 @@ from gemd.entity.bounds.real_bounds import RealBounds
 
 from gemd.enumeration.origin import Origin
 
+from gemd.units import convert_units
 
 # For now, module constant, though likely this should get promoted to a package level
 DEMO_TEMPLATE_SCOPE = 'citrine-demo-sac-template'
@@ -204,10 +205,24 @@ def make_strehlow_objects(table=None, template_scope=DEMO_TEMPLATE_SCOPE):
     def real_mapper(prop):
         """Mapping methods for RealBounds."""
         if 'uncertainty' in prop['scalars'][0]:
-            val = NormalReal(mean=float(prop['scalars'][0]['value']),
-                             units=prop['units'],
-                             std=float(prop['scalars'][0]['uncertainty'])
-                             )
+            if prop['units'] == 'eV':  # Arbitrarily convert to attojoules
+                mean = convert_units(value=float(prop['scalars'][0]['value']),
+                                     starting_unit=prop['units'],
+                                     final_unit='aJ'
+                                     )
+                std = convert_units(value=float(prop['scalars'][0]['value']),
+                                    starting_unit=prop['units'],
+                                    final_unit='aJ'
+                                    )
+                val = NormalReal(mean=mean,
+                                 units='aJ',
+                                 std=std
+                                 )
+            else:
+                val = NormalReal(mean=float(prop['scalars'][0]['value']),
+                                 units=prop['units'],
+                                 std=float(prop['scalars'][0]['uncertainty'])
+                                 )
         else:
             val = NominalReal(nominal=float(prop['scalars'][0]['value']),
                               units=prop['units']

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='gemd',
-      version='0.14.2',
+      version='0.14.3',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',


### PR DESCRIPTION
To improve the value of Strehlow and Cook in a test context, this arbitrarily maps all band gaps with an uncertainty statement into units of attojoules.  Thus, two different units are present in the resultant corpus for the same property.