### PR TITLE
Feature/change units

### DIFF
--- a/gemd/units/impl.py
+++ b/gemd/units/impl.py
@@ -62,3 +62,16 @@ def convert_units(value: float, starting_unit: str, final_unit: str) -> float:
         The converted number
     """
     return _ureg.Quantity(value, starting_unit).to(final_unit).magnitude
+
+
+def change_definitions_file(filename: str):
+    """
+    Change which file is used for units definition
+
+    Parameters
+    ----------
+    filename: str
+        The file to use
+    """
+    global _ureg
+    _ureg = UnitRegistry(filename=filename)

--- a/gemd/units/impl.py
+++ b/gemd/units/impl.py
@@ -7,7 +7,8 @@ from pint.unit import _Unit
 
 
 # use the default unit registry for now
-_ureg = UnitRegistry(filename=pkg_resources.resource_filename("gemd.units", "citrine_en.txt"))
+DEFAULT_FILE = pkg_resources.resource_filename("gemd.units", "citrine_en.txt")
+_ureg = UnitRegistry(filename=DEFAULT_FILE)
 
 
 # alias the error that is thrown when units are incompatible
@@ -65,7 +66,7 @@ def convert_units(value: float, starting_unit: str, final_unit: str) -> float:
     return _ureg.Quantity(value, starting_unit).to(final_unit).magnitude
 
 
-def change_definitions_file(filename: str):
+def change_definitions_file(filename: str = None):
     """
     Change which file is used for units definition.
 
@@ -76,4 +77,6 @@ def change_definitions_file(filename: str):
 
     """
     global _ureg
+    if filename is None:
+        filename = DEFAULT_FILE
     _ureg = UnitRegistry(filename=filename)

--- a/gemd/units/impl.py
+++ b/gemd/units/impl.py
@@ -60,18 +60,20 @@ def convert_units(value: float, starting_unit: str, final_unit: str) -> float:
     -------
     [float]
         The converted number
+
     """
     return _ureg.Quantity(value, starting_unit).to(final_unit).magnitude
 
 
 def change_definitions_file(filename: str):
     """
-    Change which file is used for units definition
+    Change which file is used for units definition.
 
     Parameters
     ----------
     filename: str
         The file to use
+
     """
     global _ureg
     _ureg = UnitRegistry(filename=filename)

--- a/gemd/units/impl.py
+++ b/gemd/units/impl.py
@@ -1,8 +1,8 @@
 """Implementation of units."""
 import pint
 import pkg_resources
+from typing import Union
 from pint import UnitRegistry
-from pint.quantity import _Quantity
 from pint.unit import _Unit
 
 
@@ -16,33 +16,49 @@ IncompatibleUnitsError = pint.errors.DimensionalityError
 UndefinedUnitError = pint.errors.UndefinedUnitError
 
 
-def _unit_to_str(unit):
-    """Helper that pulls a string representation of the unit from a quantity."""
-    if not isinstance(unit, _Quantity):
-        raise TypeError("Expecting a quantity")  # pragma: no cover
-    return str(unit.units)
+def parse_units(units: Union[str, _Unit, None]) -> Union[str, _Unit, None]:
+    """
+    Parse a string or _Unit into a standard string representation of the unit.
 
+    Parameters
+    ----------
+    units: Union[str, _Unit, None]
+        The string or _Unit representation of the object we wish to display
 
-def parse_units(units):
-    """Parse a string or _Unit into a standard string representation of the unit."""
+    Returns
+    -------
+    [Union[str, _Unit, None]]
+        The representation; note that the same type that was passed is returned
+
+    """
     if units is None:
         return None
     elif units == '':
         return 'dimensionless'
     elif isinstance(units, str):
-        return _unit_to_str(_ureg(units))
+        return str(_ureg(units).units)
     elif isinstance(units, _Unit):
         return units
     else:
         raise UndefinedUnitError("Units must be given as a recognized unit string or Units object")
 
 
-def convert_units(value, starting_unit, final_unit):
+def convert_units(value: float, starting_unit: str, final_unit: str) -> float:
     """
     Convert the value from the starting_unit to the final_unit.
 
-    :param value: magnitude to convert (number)
-    :param starting_unit: unit that the magnitude is currently in (str)
-    :param final_unit: unit that the magnitude should be returned in (str)
+    Parameters
+    ----------
+    value: float
+        magnitude to convert
+    starting_unit: str
+        unit that the magnitude is currently in
+    final_unit: str
+        unit that the magnitude should be returned in
+
+    Returns
+    -------
+    [float]
+        The converted number
     """
     return _ureg.Quantity(value, starting_unit).to(final_unit).magnitude

--- a/gemd/units/tests/test_parser.py
+++ b/gemd/units/tests/test_parser.py
@@ -44,7 +44,7 @@ def test_parse_none():
 
 
 @contextmanager
-def change_units(filename):
+def _change_units(filename):
     try:
         change_definitions_file(filename)
         yield
@@ -57,7 +57,8 @@ def test_file_change():
     assert convert_units(1, 'm', 'cm') == 100
     with pytest.raises(UndefinedUnitError):
         assert convert_units(1, 'usd', 'usd') == 1
-    with change_units(filename=pkg_resources.resource_filename("gemd.units", "tests/test_units.txt")):
+    with _change_units(filename=pkg_resources.resource_filename("gemd.units",
+                                                                "tests/test_units.txt")):
         with pytest.raises(UndefinedUnitError):
             assert convert_units(1, 'm', 'cm') == 100
         assert convert_units(1, 'usd', 'usd') == 1

--- a/gemd/units/tests/test_parser.py
+++ b/gemd/units/tests/test_parser.py
@@ -1,7 +1,7 @@
 import pytest
 import pkg_resources
 from pint import UnitRegistry
-from gemd.units import parse_units, UndefinedUnitError
+from gemd.units import parse_units, convert_units, change_definitions_file, UndefinedUnitError
 
 # use the default unit registry for now
 _ureg = UnitRegistry(filename=pkg_resources.resource_filename("gemd.units", "citrine_en.txt"))
@@ -21,6 +21,7 @@ def test_parse_expected():
     ]
     for unit in expected:
         parse_units(unit)
+    assert parse_units("") == 'dimensionless'
 
 
 def test_parse_unexpected():
@@ -39,3 +40,19 @@ def test_parse_unexpected():
 def test_parse_none():
     """Test that None parses as None."""
     assert parse_units(None) is None
+
+
+def test_file_change():
+    """Test that swapping units files works."""
+    assert convert_units(1, 'm', 'cm') == 100
+    with pytest.raises(UndefinedUnitError):
+        assert convert_units(1, 'usd', 'usd') == 1
+    change_definitions_file(
+        filename=pkg_resources.resource_filename("gemd.units", "tests/test_units.txt")
+    )
+    with pytest.raises(UndefinedUnitError):
+        assert convert_units(1, 'm', 'cm') == 100
+    assert convert_units(1, 'usd', 'usd') == 1
+    change_definitions_file(
+        filename=pkg_resources.resource_filename("gemd.units", "citrine_en.txt")
+    )

--- a/gemd/units/tests/test_units.txt
+++ b/gemd/units/tests/test_units.txt
@@ -1,0 +1,4 @@
+
+#### BASE UNITS ####
+
+usd = [currency]

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='gemd',
-      version='0.14.2',
+      version='0.15.0',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',
@@ -49,6 +49,7 @@ setup(name='gemd',
               'demo/toothpick.jpg',
               'units/citrine_en.txt',
               'units/constants_en.txt'
+              'units/tests/test_units.txt'
           ]
       },
       install_requires=[


### PR DESCRIPTION
Adding an explicit interface for changing the target units file for gemd-python.  

Most of these changes revolve around bringing the units conversion file in-line with Contributing code standards.  The private method `_unit_to_str` has also been removed as it was not used elsewhere in the module and the only effect was testing an exception that is impossible with how it is called.