### PR TITLE
Added mechanism for checking consistency between bounds and values

### DIFF
--- a/gemd/entity/bounds/base_bounds.py
+++ b/gemd/entity/bounds/base_bounds.py
@@ -30,7 +30,7 @@ class BaseBounds(DictSerializable):
         if bounds is None:
             return False
         if isinstance(bounds, BaseValue):
-            bounds = bounds.to_bounds()
+            bounds = bounds._to_bounds()
         if isinstance(bounds, BaseBounds):
             return True
         raise TypeError('{} is not a Bounds object'.format(bounds))

--- a/gemd/entity/bounds/base_bounds.py
+++ b/gemd/entity/bounds/base_bounds.py
@@ -1,5 +1,6 @@
 """Base class for all bounds."""
 from abc import abstractmethod
+from typing import Union
 
 from gemd.entity.dict_serializable import DictSerializable
 
@@ -8,14 +9,15 @@ class BaseBounds(DictSerializable):
     """Base class for bounds, including RealBounds and CategoricalBounds."""
 
     @abstractmethod
-    def contains(self, bounds):
+    def contains(self, bounds: Union["BaseBounds", "BaseValue"]):
         """
         Check if another bounds is contained within this bounds.
 
         Parameters
         ----------
-        bounds: BaseBounds
-            Other bounds object to check.
+        bounds: Union[BaseBounds, BaseValue]
+            Other bounds object to check.  If it's a Value object, check against
+            the smallest compatible bounds, as returned by the
 
         Returns
         -------
@@ -23,8 +25,12 @@ class BaseBounds(DictSerializable):
             True if any value that validates true for bounds also validates true for this
 
         """
+        from gemd.entity.value.base_value import BaseValue
+
         if bounds is None:
             return False
+        if isinstance(bounds, BaseValue):
+            bounds = bounds.to_bounds()
         if isinstance(bounds, BaseBounds):
             return True
         raise TypeError('{} is not a Bounds object'.format(bounds))

--- a/gemd/entity/bounds/categorical_bounds.py
+++ b/gemd/entity/bounds/categorical_bounds.py
@@ -2,6 +2,8 @@
 from gemd.entity.bounds.base_bounds import BaseBounds
 from gemd.entity.util import array_like
 
+from typing import Union
+
 
 class CategoricalBounds(BaseBounds):
     """
@@ -39,26 +41,30 @@ class CategoricalBounds(BaseBounds):
         if not all(isinstance(x, str) for x in self.categories):
             raise ValueError("All the categories must be strings")
 
-    def contains(self, bounds: BaseBounds) -> bool:
+    def contains(self, bounds: Union[BaseBounds, "BaseValue"]) -> bool:
         """
-        Check if another bounds object is contained by this bounds.
+        Check if another bounds object or value objects is contained by this bounds.
 
-        The other bounds must also be a CategoricalBounds and its allowed categories must be a
+        The other object must also be Categorical and its allowed categories must be a
         subset of this bounds's allowed categories.
 
         Parameters
         ----------
-        bounds: BaseBounds
-            Other bounds object to check.
+        bounds: Union[BaseBounds, BaseValue]
+            Other bounds or value object to check.
 
         Returns
         -------
         bool
-            True if the other bounds is contained by this bounds.
+            True if the other object is contained by this bounds.
 
         """
+        from gemd.entity.value.base_value import BaseValue
+
         if not super().contains(bounds):
             return False
+        if isinstance(bounds, BaseValue):
+            bounds = bounds.to_bounds()
         if not isinstance(bounds, CategoricalBounds):
             return False
 

--- a/gemd/entity/bounds/categorical_bounds.py
+++ b/gemd/entity/bounds/categorical_bounds.py
@@ -64,7 +64,7 @@ class CategoricalBounds(BaseBounds):
         if not super().contains(bounds):
             return False
         if isinstance(bounds, BaseValue):
-            bounds = bounds.to_bounds()
+            bounds = bounds._to_bounds()
         if not isinstance(bounds, CategoricalBounds):
             return False
 

--- a/gemd/entity/bounds/composition_bounds.py
+++ b/gemd/entity/bounds/composition_bounds.py
@@ -64,7 +64,7 @@ class CompositionBounds(BaseBounds):
         if not super().contains(bounds):
             return False
         if isinstance(bounds, BaseValue):
-            bounds = bounds.to_bounds()
+            bounds = bounds._to_bounds()
         if not isinstance(bounds, CompositionBounds):
             return False
 

--- a/gemd/entity/bounds/composition_bounds.py
+++ b/gemd/entity/bounds/composition_bounds.py
@@ -2,6 +2,8 @@
 from gemd.entity.bounds.base_bounds import BaseBounds
 from gemd.entity.util import array_like
 
+from typing import Union
+
 
 class CompositionBounds(BaseBounds):
     """
@@ -39,26 +41,30 @@ class CompositionBounds(BaseBounds):
         if not all(isinstance(x, str) for x in self.components):
             raise ValueError("All the components must be strings")
 
-    def contains(self, bounds: BaseBounds) -> bool:
+    def contains(self, bounds: Union[BaseBounds, "BaseValue"]) -> bool:
         """
-        Check if another bounds is contained by this bounds.
+        Check if another bounds or value object is contained by this bounds.
 
-        The other bounds must also be a CompositionBounds and its components must be a subset of
-        this bounds's set of required components.
+        The other object must also be a Composition and its components must be a subset of
+        this bounds's set of allowed components.
 
         Parameters
         ----------
-        bounds: BaseBounds
-            Other bounds object to check.
+        bounds: Union[BaseBounds, BaseValue]
+            Other object to check.
 
         Returns
         -------
         bool
-            True if the other bounds is contained by this bounds.
+            True if the other object is contained by this bounds.
 
         """
+        from gemd.entity.value.base_value import BaseValue
+
         if not super().contains(bounds):
             return False
+        if isinstance(bounds, BaseValue):
+            bounds = bounds.to_bounds()
         if not isinstance(bounds, CompositionBounds):
             return False
 

--- a/gemd/entity/bounds/integer_bounds.py
+++ b/gemd/entity/bounds/integer_bounds.py
@@ -55,7 +55,7 @@ class IntegerBounds(BaseBounds):
         if not super().contains(bounds):
             return False
         if isinstance(bounds, BaseValue):
-            bounds = bounds.to_bounds()
+            bounds = bounds._to_bounds()
         if not isinstance(bounds, IntegerBounds):
             return False
 

--- a/gemd/entity/bounds/integer_bounds.py
+++ b/gemd/entity/bounds/integer_bounds.py
@@ -1,6 +1,8 @@
 """Bounds an integer to be between two values."""
 from gemd.entity.bounds.base_bounds import BaseBounds
 
+from typing import Union
+
 
 class IntegerBounds(BaseBounds):
     """
@@ -30,26 +32,30 @@ class IntegerBounds(BaseBounds):
         if self.upper_bound < self.lower_bound:
             raise ValueError("Upper bound must be greater than or equal to lower bound")
 
-    def contains(self, bounds: BaseBounds) -> bool:
+    def contains(self, bounds: Union[BaseBounds, "BaseValue"]) -> bool:
         """
-        Check if another bounds is a subset of this range.
+        Check if another bounds or value object is a subset of this range.
 
-        The other bounds must also be an IntegerBounds and its lower and upper bound must *both*
+        The other object must also be an Integer and its lower and upper bound must *both*
         be within the range of this bounds object.
 
         Parameters
         ----------
-        bounds: BaseBounds
-            Other bounds object to check.
+        bounds: Union[BaseBounds, BaseValue]
+            Other bounds or value object to check.
 
         Returns
         -------
         bool
-            True if the other bounds is contained by this bounds.
+            True if the other object is contained by this bounds.
 
         """
+        from gemd.entity.value.base_value import BaseValue
+
         if not super().contains(bounds):
             return False
+        if isinstance(bounds, BaseValue):
+            bounds = bounds.to_bounds()
         if not isinstance(bounds, IntegerBounds):
             return False
 

--- a/gemd/entity/bounds/molecular_structure_bounds.py
+++ b/gemd/entity/bounds/molecular_structure_bounds.py
@@ -5,6 +5,8 @@ In the future, this may include substructural restrictions.
 """
 from gemd.entity.bounds.base_bounds import BaseBounds
 
+from typing import Union
+
 
 class MolecularStructureBounds(BaseBounds):
     """Molecular bounds, with no component or substructural restrictions (yet)."""
@@ -14,17 +16,17 @@ class MolecularStructureBounds(BaseBounds):
     def __init__(self):
         pass
 
-    def contains(self, bounds: BaseBounds) -> bool:
+    def contains(self, bounds: Union[BaseBounds, "BaseValue"]) -> bool:
         """
-        Check if another bounds is contained by this bounds.
+        Check if another bounds or value object is contained by this bounds.
 
-        The other bounds must also be a MolecularBounds.  There are no other
+        The other object must also be or type Molecular.  There are no other
         conditions at this time.
 
         Parameters
         ----------
-        bounds: BaseBounds
-            Other bounds object to check.
+        bounds: Union[BaseBounds, BaseValue]
+            Other bounds or value object to check.
 
         Returns
         -------
@@ -32,8 +34,12 @@ class MolecularStructureBounds(BaseBounds):
             True if the other bounds is contained by this bounds.
 
         """
+        from gemd.entity.value.base_value import BaseValue
+
         if not super().contains(bounds):
             return False
+        if isinstance(bounds, BaseValue):
+            bounds = bounds.to_bounds()
         if not isinstance(bounds, MolecularStructureBounds):
             return False
 

--- a/gemd/entity/bounds/molecular_structure_bounds.py
+++ b/gemd/entity/bounds/molecular_structure_bounds.py
@@ -39,7 +39,7 @@ class MolecularStructureBounds(BaseBounds):
         if not super().contains(bounds):
             return False
         if isinstance(bounds, BaseValue):
-            bounds = bounds.to_bounds()
+            bounds = bounds._to_bounds()
         if not isinstance(bounds, MolecularStructureBounds):
             return False
 

--- a/gemd/entity/bounds/real_bounds.py
+++ b/gemd/entity/bounds/real_bounds.py
@@ -2,6 +2,8 @@
 from gemd.entity.bounds.base_bounds import BaseBounds
 import gemd.units as units
 
+from typing import Union
+
 
 class RealBounds(BaseBounds):
     """
@@ -49,26 +51,32 @@ class RealBounds(BaseBounds):
                              "Use an empty string for a dimensionless quantity.")
         self._default_units = units.parse_units(default_units)
 
-    def contains(self, bounds: BaseBounds) -> bool:
+    def contains(self, bounds: Union[BaseBounds, "BaseValue"]) -> bool:
         """
-        Check if another bounds is a subset of this range.
+        Check if another bounds or value object is a subset of this range.
 
-        The other bounds must also be a RealBounds and its lower and upper bound must *both*
-        be within the range of this bounds object.
+        The other object must also be Real and its lower and upper bound must *both*
+        be within the range of this bounds object.  Values that are unbounded
+        distributions (e.g., Gaussian) are generally assumed to be truncated and
+        logic around permissibility is delegated to the Value implementation.
 
         Parameters
         ----------
-        bounds: BaseBounds
-            Other bounds object to check.
+        bounds: Union[BaseBounds, BaseValue]
+            Other bounds or value object to check.
 
         Returns
         -------
         bool
-            True if the other bounds is contained by this bounds.
+            True if the other object is contained by this bounds.
 
         """
+        from gemd.entity.value.base_value import BaseValue
+
         if not super().contains(bounds):
             return False
+        if isinstance(bounds, BaseValue):
+            bounds = bounds.to_bounds()
         if not isinstance(bounds, RealBounds):
             return False
 

--- a/gemd/entity/bounds/real_bounds.py
+++ b/gemd/entity/bounds/real_bounds.py
@@ -76,7 +76,7 @@ class RealBounds(BaseBounds):
         if not super().contains(bounds):
             return False
         if isinstance(bounds, BaseValue):
-            bounds = bounds.to_bounds()
+            bounds = bounds._to_bounds()
         if not isinstance(bounds, RealBounds):
             return False
 

--- a/gemd/entity/bounds/tests/test_categorical_bounds.py
+++ b/gemd/entity/bounds/tests/test_categorical_bounds.py
@@ -33,6 +33,11 @@ def test_contains():
     with pytest.raises(TypeError):
         bounds.contains({"spam", "eggs"})
 
+    from gemd.entity.value import NominalCategorical
+
+    assert bounds.contains(NominalCategorical("spam"))
+    assert not bounds.contains(NominalCategorical("foo"))
+
 
 def test_json():
     """Test that serialization works (categories is encoded as a list)."""

--- a/gemd/entity/bounds/tests/test_composition_bounds.py
+++ b/gemd/entity/bounds/tests/test_composition_bounds.py
@@ -33,6 +33,11 @@ def test_contains():
     with pytest.raises(TypeError):
         bounds.contains({"spam"})
 
+    from gemd.entity.value import NominalComposition
+
+    assert bounds.contains(NominalComposition({"spam": 0.2, "eggs": 0.8}))
+    assert not bounds.contains(NominalComposition({"foo": 1.0}))
+
 
 def test_json():
     """Test serialization (components is encoded as a list)."""

--- a/gemd/entity/bounds/tests/test_integer_bounds.py
+++ b/gemd/entity/bounds/tests/test_integer_bounds.py
@@ -34,3 +34,8 @@ def test_contains():
     assert not int_bounds.contains(None)
     with pytest.raises(TypeError):
         int_bounds.contains([0, 1])
+
+    from gemd.entity.value import NominalInteger
+
+    assert int_bounds.contains(NominalInteger(1))
+    assert not int_bounds.contains(NominalInteger(5))

--- a/gemd/entity/bounds/tests/test_molecular_structure_bounds.py
+++ b/gemd/entity/bounds/tests/test_molecular_structure_bounds.py
@@ -17,6 +17,11 @@ def test_contains():
     with pytest.raises(TypeError):
         bounds.contains('InChI=1/C8H8O3/c1-11-8-4-6(5-9)2-3-7(8)10/h2-5,10H,1H3')
 
+    from gemd.entity.value import Smiles, NominalInteger
+
+    assert bounds.contains(Smiles('c1(C=O)cc(OC)c(O)cc1'))
+    assert not bounds.contains(NominalInteger(5))
+
 
 def test_json():
     """Test that serialization works (empty dictionary)."""

--- a/gemd/entity/bounds/tests/test_real_bounds.py
+++ b/gemd/entity/bounds/tests/test_real_bounds.py
@@ -11,6 +11,11 @@ def test_contains():
     dim2 = RealBounds(lower_bound=33, upper_bound=200, default_units="degF")
     assert dim.contains(dim2)
 
+    from gemd.entity.value import NominalReal
+
+    assert dim.contains(NominalReal(5, 'degC'))
+    assert not dim.contains(NominalReal(5, 'K'))
+
 
 def test_contains_no_units():
     """Make sure contains handles boundsless values."""

--- a/gemd/entity/value/base_value.py
+++ b/gemd/entity/value/base_value.py
@@ -28,4 +28,3 @@ class BaseValue(DictSerializable):
             :class:`bounds <gemd.entity.bounds.base_bounds.BaseBounds>`.
 
         """
-        pass

--- a/gemd/entity/value/base_value.py
+++ b/gemd/entity/value/base_value.py
@@ -17,7 +17,7 @@ class BaseValue(DictSerializable):
     typ = "value"
 
     @abstractmethod
-    def to_bounds(self) -> BaseBounds:
+    def _to_bounds(self) -> BaseBounds:
         """
         Return the smallest bounds object that is consistent with the Value.
 

--- a/gemd/entity/value/base_value.py
+++ b/gemd/entity/value/base_value.py
@@ -1,5 +1,8 @@
 """Base class for all values."""
 from gemd.entity.dict_serializable import DictSerializable
+from gemd.entity.bounds.base_bounds import BaseBounds
+
+from abc import abstractmethod
 
 
 class BaseValue(DictSerializable):
@@ -12,3 +15,17 @@ class BaseValue(DictSerializable):
     """
 
     typ = "value"
+
+    @abstractmethod
+    def to_bounds(self) -> BaseBounds:
+        """
+        Return the smallest bounds object that is consistent with the Value.
+
+        Returns
+        -------
+        BaseBounds
+            The minimally consistent
+            :class:`bounds <gemd.entity.bounds.base_bounds.BaseBounds>`.
+
+        """
+        pass

--- a/gemd/entity/value/categorical_value.py
+++ b/gemd/entity/value/categorical_value.py
@@ -24,4 +24,3 @@ class CategoricalValue(BaseValue):
             :class:`bounds <gemd.entity.bounds.categorical_bounds.CategoricalBounds>`.
 
         """
-        pass

--- a/gemd/entity/value/categorical_value.py
+++ b/gemd/entity/value/categorical_value.py
@@ -1,5 +1,8 @@
 """Base class for categorical values."""
 from gemd.entity.value.base_value import BaseValue
+from gemd.entity.bounds import CategoricalBounds
+
+from abc import abstractmethod
 
 
 class CategoricalValue(BaseValue):
@@ -8,3 +11,17 @@ class CategoricalValue(BaseValue):
 
     All category names must be in unicode.
     """
+
+    @abstractmethod
+    def to_bounds(self) -> CategoricalBounds:
+        """
+        Return the smallest bounds object that is consistent with the Value.
+
+        Returns
+        -------
+        CategoricalBounds
+            The minimally consistent
+            :class:`bounds <gemd.entity.bounds.categorical_bounds.CategoricalBounds>`.
+
+        """
+        pass

--- a/gemd/entity/value/categorical_value.py
+++ b/gemd/entity/value/categorical_value.py
@@ -13,7 +13,7 @@ class CategoricalValue(BaseValue):
     """
 
     @abstractmethod
-    def to_bounds(self) -> CategoricalBounds:
+    def _to_bounds(self) -> CategoricalBounds:
         """
         Return the smallest bounds object that is consistent with the Value.
 

--- a/gemd/entity/value/composition_value.py
+++ b/gemd/entity/value/composition_value.py
@@ -20,4 +20,3 @@ class CompositionValue(BaseValue):
             :class:`bounds <gemd.entity.bounds.composition_bounds.CompositionBounds>`.
 
         """
-        pass

--- a/gemd/entity/value/composition_value.py
+++ b/gemd/entity/value/composition_value.py
@@ -1,6 +1,23 @@
 """Composition of a material."""
 from gemd.entity.value.base_value import BaseValue
+from gemd.entity.bounds import CompositionBounds
+
+from abc import abstractmethod
 
 
 class CompositionValue(BaseValue):
     """Base class for composition values."""
+
+    @abstractmethod
+    def to_bounds(self) -> CompositionBounds:
+        """
+        Return the smallest bounds object that is consistent with the Value.
+
+        Returns
+        -------
+        CompositionBounds
+            The minimally consistent
+            :class:`bounds <gemd.entity.bounds.composition_bounds.CompositionBounds>`.
+
+        """
+        pass

--- a/gemd/entity/value/composition_value.py
+++ b/gemd/entity/value/composition_value.py
@@ -9,7 +9,7 @@ class CompositionValue(BaseValue):
     """Base class for composition values."""
 
     @abstractmethod
-    def to_bounds(self) -> CompositionBounds:
+    def _to_bounds(self) -> CompositionBounds:
         """
         Return the smallest bounds object that is consistent with the Value.
 

--- a/gemd/entity/value/continuous_value.py
+++ b/gemd/entity/value/continuous_value.py
@@ -28,12 +28,12 @@ class ContinuousValue(BaseValue):
         self.units = units
 
     @property
-    def units(self):
+    def units(self) -> str:
         """Get the units of the value."""
         return self._units
 
     @units.setter
-    def units(self, units):
+    def units(self, units: str):
         if units is None:
             raise ValueError("Continuous values must have units. "
                              "Use an empty string for a dimensionless quantity.")

--- a/gemd/entity/value/continuous_value.py
+++ b/gemd/entity/value/continuous_value.py
@@ -51,4 +51,3 @@ class ContinuousValue(BaseValue):
             :class:`bounds <gemd.entity.bounds.real_bounds.RealBounds>`.
 
         """
-        pass

--- a/gemd/entity/value/continuous_value.py
+++ b/gemd/entity/value/continuous_value.py
@@ -40,7 +40,7 @@ class ContinuousValue(BaseValue):
         self._units = parse_units(units)
 
     @abstractmethod
-    def to_bounds(self) -> RealBounds:
+    def _to_bounds(self) -> RealBounds:
         """
         Return the smallest bounds object that is consistent with the Value.
 

--- a/gemd/entity/value/continuous_value.py
+++ b/gemd/entity/value/continuous_value.py
@@ -1,6 +1,9 @@
 """Base class for all continuous values."""
 from gemd.entity.value.base_value import BaseValue
 from gemd.units import parse_units
+from gemd.entity.bounds import RealBounds
+
+from abc import abstractmethod
 
 
 class ContinuousValue(BaseValue):
@@ -16,7 +19,7 @@ class ContinuousValue(BaseValue):
         Examples of acceptable units: 'm', 'meter', 'metre', 'm/s^2', 'degC', 'N/meter^2',
         'joule', 'J', 'dimensionless', ''.
 
-        Examples of unacceptable units: 'Joule', 'JOULE'.
+        Examples of unacceptable units: 'JOULE'.
 
     """
 
@@ -35,3 +38,17 @@ class ContinuousValue(BaseValue):
             raise ValueError("Continuous values must have units. "
                              "Use an empty string for a dimensionless quantity.")
         self._units = parse_units(units)
+
+    @abstractmethod
+    def to_bounds(self) -> RealBounds:
+        """
+        Return the smallest bounds object that is consistent with the Value.
+
+        Returns
+        -------
+        RealBounds
+            The minimally consistent
+            :class:`bounds <gemd.entity.bounds.real_bounds.RealBounds>`.
+
+        """
+        pass

--- a/gemd/entity/value/discrete_categorical.py
+++ b/gemd/entity/value/discrete_categorical.py
@@ -30,12 +30,12 @@ class DiscreteCategorical(CategoricalValue):
         self.probabilities = probabilities
 
     @property
-    def probabilities(self):
+    def probabilities(self) -> dict:
         """Get the map from categories to probabilities."""
         return self._probabilities
 
     @probabilities.setter
-    def probabilities(self, probabilities):
+    def probabilities(self, probabilities: dict):
         if probabilities is None:
             self._probabilities = None
         elif isinstance(probabilities, str):

--- a/gemd/entity/value/discrete_categorical.py
+++ b/gemd/entity/value/discrete_categorical.py
@@ -3,6 +3,7 @@ from toolz import keymap
 
 from gemd.entity.setters import validate_str
 from gemd.entity.value.categorical_value import CategoricalValue
+from gemd.entity.bounds import CategoricalBounds
 
 
 class DiscreteCategorical(CategoricalValue):
@@ -45,3 +46,16 @@ class DiscreteCategorical(CategoricalValue):
             self._probabilities = keymap(validate_str, probabilities)
         else:
             raise TypeError("probabilities must be dict or single value")
+
+    def to_bounds(self) -> CategoricalBounds:
+        """
+        Return the smallest bounds object that is consistent with the Value.
+
+        Returns
+        -------
+        BaseBounds
+            The minimally consistent
+            :class:`bounds <gemd.entity.bounds.categorical_bounds.CategoricalBounds>`.
+
+        """
+        return CategoricalBounds(categories=set(self.probabilities))

--- a/gemd/entity/value/discrete_categorical.py
+++ b/gemd/entity/value/discrete_categorical.py
@@ -47,7 +47,7 @@ class DiscreteCategorical(CategoricalValue):
         else:
             raise TypeError("probabilities must be dict or single value")
 
-    def to_bounds(self) -> CategoricalBounds:
+    def _to_bounds(self) -> CategoricalBounds:
         """
         Return the smallest bounds object that is consistent with the Value.
 

--- a/gemd/entity/value/empirical_formula.py
+++ b/gemd/entity/value/empirical_formula.py
@@ -55,7 +55,7 @@ class EmpiricalFormula(CompositionValue):
         else:
             raise TypeError("Formula must be given as a string; got {}".format(type(value)))
 
-    def to_bounds(self) -> CompositionBounds:
+    def _to_bounds(self) -> CompositionBounds:
         """
         Return the smallest bounds object that is consistent with the Value.
 

--- a/gemd/entity/value/empirical_formula.py
+++ b/gemd/entity/value/empirical_formula.py
@@ -33,7 +33,7 @@ class EmpiricalFormula(CompositionValue):
         self.formula = formula
 
     @property
-    def formula(self):
+    def formula(self) -> str:
         """Get the formula as a string."""
         return self._formula
 
@@ -43,7 +43,7 @@ class EmpiricalFormula(CompositionValue):
         return set(re.findall('[A-Z][a-z]*', value))
 
     @formula.setter
-    def formula(self, value):
+    def formula(self, value: str):
         if value is None:
             self._formula = None
         elif isinstance(value, str):
@@ -69,6 +69,6 @@ class EmpiricalFormula(CompositionValue):
         return CompositionBounds(components=EmpiricalFormula._elements(self.formula))
 
     @staticmethod
-    def all_elements():
+    def all_elements() -> set:
         """The set of all elements in the periodic table."""
         return _all_elements

--- a/gemd/entity/value/empirical_formula.py
+++ b/gemd/entity/value/empirical_formula.py
@@ -1,5 +1,6 @@
 """An empirical chemical formaula."""
 from gemd.entity.value.composition_value import CompositionValue
+from gemd.entity.bounds import CompositionBounds
 
 
 _all_elements = {
@@ -36,14 +37,36 @@ class EmpiricalFormula(CompositionValue):
         """Get the formula as a string."""
         return self._formula
 
+    @staticmethod
+    def _elements(value: str):
+        import re
+        return set(re.findall('[A-Z][a-z]*', value))
+
     @formula.setter
     def formula(self, value):
         if value is None:
             self._formula = None
         elif isinstance(value, str):
+            if not EmpiricalFormula._elements(value).issubset(_all_elements):
+                unknown = sorted(EmpiricalFormula._elements(value).difference(_all_elements))
+                raise ValueError('Formula {} contains unknown elements: {}'
+                                 .format(value, ' '.join(unknown)))
             self._formula = value
         else:
             raise TypeError("Formula must be given as a string; got {}".format(type(value)))
+
+    def to_bounds(self) -> CompositionBounds:
+        """
+        Return the smallest bounds object that is consistent with the Value.
+
+        Returns
+        -------
+        BaseBounds
+            The minimally consistent
+            :class:`bounds <gemd.entity.bounds.categorical_bounds.CategoricalBounds>`.
+
+        """
+        return CompositionBounds(components=EmpiricalFormula._elements(self.formula))
 
     @staticmethod
     def all_elements():

--- a/gemd/entity/value/inchi_value.py
+++ b/gemd/entity/value/inchi_value.py
@@ -21,12 +21,12 @@ class InChI(MolecularValue):
         self.inchi = inchi
 
     @property
-    def inchi(self):
+    def inchi(self) -> str:
         """Get the formula as a string."""
         return self._inchi
 
     @inchi.setter
-    def inchi(self, value):
+    def inchi(self, value: str):
         if value is None:
             self._inchi = None
         elif isinstance(value, str):

--- a/gemd/entity/value/inchi_value.py
+++ b/gemd/entity/value/inchi_value.py
@@ -34,7 +34,7 @@ class InChI(MolecularValue):
         else:
             raise TypeError("InChI must be given as a string; got {}".format(type(value)))
 
-    def to_bounds(self) -> MolecularStructureBounds:
+    def _to_bounds(self) -> MolecularStructureBounds:
         """
         Return the smallest bounds object that is consistent with the Value.
 

--- a/gemd/entity/value/inchi_value.py
+++ b/gemd/entity/value/inchi_value.py
@@ -1,5 +1,6 @@
 """An empirical chemical formaula."""
 from gemd.entity.value.molecular_value import MolecularValue
+from gemd.entity.bounds import MolecularStructureBounds
 
 
 class InChI(MolecularValue):
@@ -32,3 +33,17 @@ class InChI(MolecularValue):
             self._inchi = value
         else:
             raise TypeError("InChI must be given as a string; got {}".format(type(value)))
+
+    def to_bounds(self) -> MolecularStructureBounds:
+        """
+        Return the smallest bounds object that is consistent with the Value.
+
+        Returns
+        -------
+        MolecularStructureBounds
+            The minimally consistent
+            :class:`bounds
+            <gemd.entity.bounds.molecular_structure_bounds.MolecularStructureBounds>`.
+
+        """
+        return MolecularStructureBounds()

--- a/gemd/entity/value/integer_value.py
+++ b/gemd/entity/value/integer_value.py
@@ -9,7 +9,7 @@ class IntegerValue(BaseValue):
     """A base class for values that correspond to a distribution over the integers."""
 
     @abstractmethod
-    def to_bounds(self) -> IntegerBounds:
+    def _to_bounds(self) -> IntegerBounds:
         """
         Return the smallest bounds object that is consistent with the Value.
 

--- a/gemd/entity/value/integer_value.py
+++ b/gemd/entity/value/integer_value.py
@@ -20,4 +20,3 @@ class IntegerValue(BaseValue):
             :class:`bounds <gemd.entity.bounds.integer_bounds.IntegerBounds>`.
 
         """
-        pass

--- a/gemd/entity/value/integer_value.py
+++ b/gemd/entity/value/integer_value.py
@@ -1,6 +1,23 @@
 """Base class for integer values."""
 from gemd.entity.value.base_value import BaseValue
+from gemd.entity.bounds import IntegerBounds
+
+from abc import abstractmethod
 
 
 class IntegerValue(BaseValue):
     """A base class for values that correspond to a distribution over the integers."""
+
+    @abstractmethod
+    def to_bounds(self) -> IntegerBounds:
+        """
+        Return the smallest bounds object that is consistent with the Value.
+
+        Returns
+        -------
+        IntegerBounds
+            The minimally consistent
+            :class:`bounds <gemd.entity.bounds.integer_bounds.IntegerBounds>`.
+
+        """
+        pass

--- a/gemd/entity/value/molecular_value.py
+++ b/gemd/entity/value/molecular_value.py
@@ -1,6 +1,24 @@
 """Composition of a material."""
 from gemd.entity.value.base_value import BaseValue
+from gemd.entity.bounds import MolecularStructureBounds
+
+from abc import abstractmethod
 
 
 class MolecularValue(BaseValue):
     """Base class for molecular structure values."""
+
+    @abstractmethod
+    def to_bounds(self) -> MolecularStructureBounds:
+        """
+        Return the smallest bounds object that is consistent with the Value.
+
+        Returns
+        -------
+        MolecularStructureBounds
+            The minimally consistent
+            :class:`bounds
+            <gemd.entity.bounds.molecular_structure_bounds.MolecularStructureBounds>`.
+
+        """
+        pass

--- a/gemd/entity/value/molecular_value.py
+++ b/gemd/entity/value/molecular_value.py
@@ -9,7 +9,7 @@ class MolecularValue(BaseValue):
     """Base class for molecular structure values."""
 
     @abstractmethod
-    def to_bounds(self) -> MolecularStructureBounds:
+    def _to_bounds(self) -> MolecularStructureBounds:
         """
         Return the smallest bounds object that is consistent with the Value.
 

--- a/gemd/entity/value/molecular_value.py
+++ b/gemd/entity/value/molecular_value.py
@@ -21,4 +21,3 @@ class MolecularValue(BaseValue):
             <gemd.entity.bounds.molecular_structure_bounds.MolecularStructureBounds>`.
 
         """
-        pass

--- a/gemd/entity/value/nominal_categorical.py
+++ b/gemd/entity/value/nominal_categorical.py
@@ -22,12 +22,12 @@ class NominalCategorical(CategoricalValue):
         self.category = category
 
     @property
-    def category(self):
+    def category(self) -> str:
         """Get the category."""
         return self._category
 
     @category.setter
-    def category(self, category):
+    def category(self, category: str):
         if category is None:
             self._category = None
         else:

--- a/gemd/entity/value/nominal_categorical.py
+++ b/gemd/entity/value/nominal_categorical.py
@@ -1,6 +1,7 @@
 """A value that nominally is equal to a single category."""
 from gemd.entity.setters import validate_str
 from gemd.entity.value.categorical_value import CategoricalValue
+from gemd.entity.bounds import CategoricalBounds
 
 
 class NominalCategorical(CategoricalValue):
@@ -31,3 +32,16 @@ class NominalCategorical(CategoricalValue):
             self._category = None
         else:
             self._category = validate_str(category)
+
+    def to_bounds(self) -> CategoricalBounds:
+        """
+        Return the smallest bounds object that is consistent with the Value.
+
+        Returns
+        -------
+        BaseBounds
+            The minimally consistent
+            :class:`bounds <gemd.entity.bounds.categorical_bounds.CategoricalBounds>`.
+
+        """
+        return CategoricalBounds(categories={self.category})

--- a/gemd/entity/value/nominal_categorical.py
+++ b/gemd/entity/value/nominal_categorical.py
@@ -33,7 +33,7 @@ class NominalCategorical(CategoricalValue):
         else:
             self._category = validate_str(category)
 
-    def to_bounds(self) -> CategoricalBounds:
+    def _to_bounds(self) -> CategoricalBounds:
         """
         Return the smallest bounds object that is consistent with the Value.
 

--- a/gemd/entity/value/nominal_composition.py
+++ b/gemd/entity/value/nominal_composition.py
@@ -44,7 +44,7 @@ class NominalComposition(CompositionValue):
         else:
             raise TypeError("quantities must be dict or List of two-item lists or None")
 
-    def to_bounds(self) -> CompositionBounds:
+    def _to_bounds(self) -> CompositionBounds:
         """
         Return the smallest bounds object that is consistent with the Value.
 

--- a/gemd/entity/value/nominal_composition.py
+++ b/gemd/entity/value/nominal_composition.py
@@ -1,5 +1,6 @@
 """A nominal composition value."""
 from gemd.entity.value.composition_value import CompositionValue
+from gemd.entity.bounds import CompositionBounds
 
 
 class NominalComposition(CompositionValue):
@@ -42,3 +43,16 @@ class NominalComposition(CompositionValue):
             self._quantities = dict(quantities)
         else:
             raise TypeError("quantities must be dict or List of two-item lists or None")
+
+    def to_bounds(self) -> CompositionBounds:
+        """
+        Return the smallest bounds object that is consistent with the Value.
+
+        Returns
+        -------
+        BaseBounds
+            The minimally consistent
+            :class:`bounds <gemd.entity.bounds.categorical_bounds.CategoricalBounds>`.
+
+        """
+        return CompositionBounds(components=set(self.quantities))

--- a/gemd/entity/value/nominal_composition.py
+++ b/gemd/entity/value/nominal_composition.py
@@ -29,12 +29,12 @@ class NominalComposition(CompositionValue):
         self.quantities = quantities
 
     @property
-    def quantities(self):
+    def quantities(self) -> dict:
         """Get a map from the components to their quantities."""
         return self._quantities
 
     @quantities.setter
-    def quantities(self, quantities):
+    def quantities(self, quantities: dict):
         if quantities is None:
             self._quantities = {}
         elif isinstance(quantities, dict):

--- a/gemd/entity/value/nominal_integer.py
+++ b/gemd/entity/value/nominal_integer.py
@@ -34,7 +34,7 @@ class NominalInteger(IntegerValue):
 
         self._nominal = int(nominal)
 
-    def to_bounds(self) -> IntegerBounds:
+    def _to_bounds(self) -> IntegerBounds:
         """
         Return the smallest bounds object that is consistent with the Value.
 

--- a/gemd/entity/value/nominal_integer.py
+++ b/gemd/entity/value/nominal_integer.py
@@ -1,5 +1,6 @@
 """A nominal integer value."""
 from gemd.entity.value.integer_value import IntegerValue
+from gemd.entity.bounds import IntegerBounds
 
 
 class NominalInteger(IntegerValue):
@@ -32,3 +33,16 @@ class NominalInteger(IntegerValue):
             raise TypeError("nominal must be an int; got an {}({})".format(type(nominal), nominal))
 
         self._nominal = int(nominal)
+
+    def to_bounds(self) -> IntegerBounds:
+        """
+        Return the smallest bounds object that is consistent with the Value.
+
+        Returns
+        -------
+        IntegerBounds
+            The minimally consistent
+            :class:`bounds <gemd.entity.bounds.integer_bounds.IntegerBounds>`.
+
+        """
+        return IntegerBounds(lower_bound=self.nominal, upper_bound=self.nominal)

--- a/gemd/entity/value/nominal_real.py
+++ b/gemd/entity/value/nominal_real.py
@@ -1,5 +1,6 @@
 """A nominal real value."""
 from gemd.entity.value.continuous_value import ContinuousValue
+from gemd.entity.bounds import RealBounds
 
 
 class NominalReal(ContinuousValue):
@@ -23,3 +24,18 @@ class NominalReal(ContinuousValue):
         assert isinstance(nominal, (int, float)), \
             "nominal value must be an int or float"
         self.nominal = float(nominal)
+
+    def to_bounds(self) -> RealBounds:
+        """
+        Return the smallest bounds object that is consistent with the Value.
+
+        Returns
+        -------
+        RealBounds
+            The minimally consistent
+            :class:`bounds <gemd.entity.bounds.real_bounds.RealBounds>`.
+
+        """
+        return RealBounds(lower_bound=self.nominal,
+                          upper_bound=self.nominal,
+                          default_units=self.units)

--- a/gemd/entity/value/nominal_real.py
+++ b/gemd/entity/value/nominal_real.py
@@ -25,7 +25,7 @@ class NominalReal(ContinuousValue):
             "nominal value must be an int or float"
         self.nominal = float(nominal)
 
-    def to_bounds(self) -> RealBounds:
+    def _to_bounds(self) -> RealBounds:
         """
         Return the smallest bounds object that is consistent with the Value.
 

--- a/gemd/entity/value/normal_real.py
+++ b/gemd/entity/value/normal_real.py
@@ -26,7 +26,7 @@ class NormalReal(ContinuousValue):
         self.mean = mean
         self.std = std
 
-    def to_bounds(self) -> RealBounds:
+    def _to_bounds(self) -> RealBounds:
         """
         Return the smallest bounds object that is consistent with the Value.
 

--- a/gemd/entity/value/normal_real.py
+++ b/gemd/entity/value/normal_real.py
@@ -1,5 +1,6 @@
 """A normally distributed real value."""
 from gemd.entity.value.continuous_value import ContinuousValue
+from gemd.entity.bounds import RealBounds
 
 
 class NormalReal(ContinuousValue):
@@ -24,3 +25,18 @@ class NormalReal(ContinuousValue):
         ContinuousValue.__init__(self, units)
         self.mean = mean
         self.std = std
+
+    def to_bounds(self) -> RealBounds:
+        """
+        Return the smallest bounds object that is consistent with the Value.
+
+        Returns
+        -------
+        RealBounds
+            The minimally consistent
+            :class:`bounds <gemd.entity.bounds.real_bounds.RealBounds>`.
+
+        """
+        return RealBounds(lower_bound=self.mean,
+                          upper_bound=self.mean,
+                          default_units=self.units)

--- a/gemd/entity/value/smiles_value.py
+++ b/gemd/entity/value/smiles_value.py
@@ -35,7 +35,7 @@ class Smiles(MolecularValue):
         else:
             raise TypeError("SMILES must be given as a string; got {}".format(type(value)))
 
-    def to_bounds(self) -> MolecularStructureBounds:
+    def _to_bounds(self) -> MolecularStructureBounds:
         """
         Return the smallest bounds object that is consistent with the Value.
 

--- a/gemd/entity/value/smiles_value.py
+++ b/gemd/entity/value/smiles_value.py
@@ -22,12 +22,12 @@ class Smiles(MolecularValue):
         self.smiles = smiles
 
     @property
-    def smiles(self):
+    def smiles(self) -> str:
         """Get the formula as a string."""
         return self._smiles
 
     @smiles.setter
-    def smiles(self, value):
+    def smiles(self, value: str):
         if value is None:
             self._smiles = None
         elif isinstance(value, str):

--- a/gemd/entity/value/smiles_value.py
+++ b/gemd/entity/value/smiles_value.py
@@ -1,5 +1,6 @@
 """An empirical chemical formaula."""
 from gemd.entity.value.molecular_value import MolecularValue
+from gemd.entity.bounds import MolecularStructureBounds
 
 
 class Smiles(MolecularValue):
@@ -33,3 +34,17 @@ class Smiles(MolecularValue):
             self._smiles = value
         else:
             raise TypeError("SMILES must be given as a string; got {}".format(type(value)))
+
+    def to_bounds(self) -> MolecularStructureBounds:
+        """
+        Return the smallest bounds object that is consistent with the Value.
+
+        Returns
+        -------
+        MolecularStructureBounds
+            The minimally consistent
+            :class:`bounds
+            <gemd.entity.bounds.molecular_structure_bounds.MolecularStructureBounds>`.
+
+        """
+        return MolecularStructureBounds()

--- a/gemd/entity/value/tests/test_discrete_categorical.py
+++ b/gemd/entity/value/tests/test_discrete_categorical.py
@@ -2,6 +2,7 @@
 import pytest
 
 from gemd.entity.value.discrete_categorical import DiscreteCategorical
+from gemd.entity.bounds import CategoricalBounds
 
 
 def test_probabilities_setter():
@@ -19,3 +20,10 @@ def test_invalid_assignment():
         DiscreteCategorical(probabilities=["solid", "liquid"])
     with pytest.raises(ValueError):
         DiscreteCategorical(probabilities={"solid": 0.9, "liquid": 0.2})
+
+
+def test_contains():
+    """Test that bounds know if a Value is contained within it."""
+    bounds = CategoricalBounds({"solid", "liquid"})
+    assert bounds.contains(DiscreteCategorical({"solid": 0.9, "liquid": 0.1}).to_bounds())
+    assert not bounds.contains(DiscreteCategorical({"solid": 0.9, "gas": 0.1}).to_bounds())

--- a/gemd/entity/value/tests/test_discrete_categorical.py
+++ b/gemd/entity/value/tests/test_discrete_categorical.py
@@ -25,5 +25,5 @@ def test_invalid_assignment():
 def test_contains():
     """Test that bounds know if a Value is contained within it."""
     bounds = CategoricalBounds({"solid", "liquid"})
-    assert bounds.contains(DiscreteCategorical({"solid": 0.9, "liquid": 0.1}).to_bounds())
-    assert not bounds.contains(DiscreteCategorical({"solid": 0.9, "gas": 0.1}).to_bounds())
+    assert bounds.contains(DiscreteCategorical({"solid": 0.9, "liquid": 0.1})._to_bounds())
+    assert not bounds.contains(DiscreteCategorical({"solid": 0.9, "gas": 0.1})._to_bounds())

--- a/gemd/entity/value/tests/test_empirical_formula.py
+++ b/gemd/entity/value/tests/test_empirical_formula.py
@@ -40,5 +40,5 @@ def test_invalid_formula():
 def test_contains():
     """Test that bounds know if a Value is contained within it."""
     bounds = CompositionBounds({"C", "H", "O", "N"})
-    assert bounds.contains(EmpiricalFormula('C2H5OH').to_bounds())
-    assert not bounds.contains(EmpiricalFormula('NaCl').to_bounds())
+    assert bounds.contains(EmpiricalFormula('C2H5OH')._to_bounds())
+    assert not bounds.contains(EmpiricalFormula('NaCl')._to_bounds())

--- a/gemd/entity/value/tests/test_empirical_formula.py
+++ b/gemd/entity/value/tests/test_empirical_formula.py
@@ -3,6 +3,7 @@ import pytest
 
 from gemd.json import dumps, loads
 from gemd.entity.value.empirical_formula import EmpiricalFormula
+from gemd.entity.bounds import CompositionBounds
 
 
 def test_all_elements():
@@ -32,3 +33,12 @@ def test_invalid_formula():
     """Check that an invalid formula throws a TypeError."""
     with pytest.raises(TypeError):
         EmpiricalFormula(formula={"Al": 2, "O": 3})
+    with pytest.raises(ValueError):
+        EmpiricalFormula(formula="WoRdS")
+
+
+def test_contains():
+    """Test that bounds know if a Value is contained within it."""
+    bounds = CompositionBounds({"C", "H", "O", "N"})
+    assert bounds.contains(EmpiricalFormula('C2H5OH').to_bounds())
+    assert not bounds.contains(EmpiricalFormula('NaCl').to_bounds())

--- a/gemd/entity/value/tests/test_inchi.py
+++ b/gemd/entity/value/tests/test_inchi.py
@@ -3,6 +3,7 @@ import pytest
 
 from gemd.json import dumps, loads
 from gemd.entity.value.inchi_value import InChI
+from gemd.entity.bounds import MolecularStructureBounds
 
 
 def test_json():
@@ -29,3 +30,10 @@ def test_invalid_inchi():
     """
     with pytest.raises(TypeError):
         InChI({"Al": 2, "O": 3})
+
+
+def test_contains():
+    """Test that bounds know if a Value is contained within it."""
+    bounds = MolecularStructureBounds()
+    inchi = InChI("InChI=1/C8H8O3/c1-11-8-4-6(5-9)2-3-7(8)10/h2-5,10H,1H3")
+    assert bounds.contains(inchi.to_bounds())

--- a/gemd/entity/value/tests/test_inchi.py
+++ b/gemd/entity/value/tests/test_inchi.py
@@ -36,4 +36,4 @@ def test_contains():
     """Test that bounds know if a Value is contained within it."""
     bounds = MolecularStructureBounds()
     inchi = InChI("InChI=1/C8H8O3/c1-11-8-4-6(5-9)2-3-7(8)10/h2-5,10H,1H3")
-    assert bounds.contains(inchi.to_bounds())
+    assert bounds.contains(inchi._to_bounds())

--- a/gemd/entity/value/tests/test_nomial_integer.py
+++ b/gemd/entity/value/tests/test_nomial_integer.py
@@ -2,6 +2,7 @@
 import pytest
 
 from gemd.entity.value.nominal_integer import NominalInteger
+from gemd.entity.bounds import IntegerBounds
 
 
 def test_bounds_are_integers():
@@ -11,3 +12,10 @@ def test_bounds_are_integers():
         NominalInteger(5.7)
     with pytest.raises(TypeError):
         NominalInteger("five")
+
+
+def test_contains():
+    """Test that bounds know if a Value is contained within it."""
+    bounds = IntegerBounds(1, 3)
+    assert bounds.contains(NominalInteger(2).to_bounds())
+    assert not bounds.contains(NominalInteger(5).to_bounds())

--- a/gemd/entity/value/tests/test_nomial_integer.py
+++ b/gemd/entity/value/tests/test_nomial_integer.py
@@ -17,5 +17,5 @@ def test_bounds_are_integers():
 def test_contains():
     """Test that bounds know if a Value is contained within it."""
     bounds = IntegerBounds(1, 3)
-    assert bounds.contains(NominalInteger(2).to_bounds())
-    assert not bounds.contains(NominalInteger(5).to_bounds())
+    assert bounds.contains(NominalInteger(2)._to_bounds())
+    assert not bounds.contains(NominalInteger(5)._to_bounds())

--- a/gemd/entity/value/tests/test_nominal_categorical.py
+++ b/gemd/entity/value/tests/test_nominal_categorical.py
@@ -15,5 +15,5 @@ def test_category_setter():
 def test_contains():
     """Test that bounds know if a Value is contained within it."""
     bounds = CategoricalBounds({"solid", "liquid"})
-    assert bounds.contains(NominalCategorical("solid").to_bounds())
-    assert not bounds.contains(NominalCategorical("gas").to_bounds())
+    assert bounds.contains(NominalCategorical("solid")._to_bounds())
+    assert not bounds.contains(NominalCategorical("gas")._to_bounds())

--- a/gemd/entity/value/tests/test_nominal_categorical.py
+++ b/gemd/entity/value/tests/test_nominal_categorical.py
@@ -1,5 +1,6 @@
 """Tests of the NominalCategorical class."""
 from gemd.entity.value.nominal_categorical import NominalCategorical
+from gemd.entity.bounds import CategoricalBounds
 
 
 def test_category_setter():
@@ -9,3 +10,10 @@ def test_category_setter():
     assert test_categorical.category is None
     test_categorical.category = test_category
     assert test_categorical.category == test_category
+
+
+def test_contains():
+    """Test that bounds know if a Value is contained within it."""
+    bounds = CategoricalBounds({"solid", "liquid"})
+    assert bounds.contains(NominalCategorical("solid").to_bounds())
+    assert not bounds.contains(NominalCategorical("gas").to_bounds())

--- a/gemd/entity/value/tests/test_nominal_composition.py
+++ b/gemd/entity/value/tests/test_nominal_composition.py
@@ -2,6 +2,7 @@
 import pytest
 
 from gemd.entity.value.nominal_composition import NominalComposition
+from gemd.entity.bounds import CompositionBounds
 
 
 def test_quantities_are_dict():
@@ -18,3 +19,10 @@ def test_invalid_assignment():
     """Test that invalid assignment produces a TypeError."""
     with pytest.raises(TypeError):
         NominalComposition(("a quantity", 55))
+
+
+def test_contains():
+    """Test that bounds know if a Value is contained within it."""
+    bounds = CompositionBounds({"acetone", "methanol"})
+    assert bounds.contains(NominalComposition(dict(acetone=0.25, methanol=0.75)).to_bounds())
+    assert not bounds.contains(NominalComposition(dict(acetone=0.25, water=0.75)).to_bounds())

--- a/gemd/entity/value/tests/test_nominal_composition.py
+++ b/gemd/entity/value/tests/test_nominal_composition.py
@@ -24,5 +24,5 @@ def test_invalid_assignment():
 def test_contains():
     """Test that bounds know if a Value is contained within it."""
     bounds = CompositionBounds({"acetone", "methanol"})
-    assert bounds.contains(NominalComposition(dict(acetone=0.25, methanol=0.75)).to_bounds())
-    assert not bounds.contains(NominalComposition(dict(acetone=0.25, water=0.75)).to_bounds())
+    assert bounds.contains(NominalComposition(dict(acetone=0.25, methanol=0.75))._to_bounds())
+    assert not bounds.contains(NominalComposition(dict(acetone=0.25, water=0.75))._to_bounds())

--- a/gemd/entity/value/tests/test_nominal_real.py
+++ b/gemd/entity/value/tests/test_nominal_real.py
@@ -1,0 +1,10 @@
+"""Tests of the NominalReal class."""
+from gemd.entity.value.nominal_real import NominalReal
+from gemd.entity.bounds import RealBounds
+
+
+def test_contains():
+    """Test that bounds know if a Value is contained within it."""
+    bounds = RealBounds(1, 3, 'm')
+    assert bounds.contains(NominalReal(200, 'cm').to_bounds())
+    assert not bounds.contains(NominalReal(5, 'm').to_bounds())

--- a/gemd/entity/value/tests/test_nominal_real.py
+++ b/gemd/entity/value/tests/test_nominal_real.py
@@ -6,5 +6,5 @@ from gemd.entity.bounds import RealBounds
 def test_contains():
     """Test that bounds know if a Value is contained within it."""
     bounds = RealBounds(1, 3, 'm')
-    assert bounds.contains(NominalReal(200, 'cm').to_bounds())
-    assert not bounds.contains(NominalReal(5, 'm').to_bounds())
+    assert bounds.contains(NominalReal(200, 'cm')._to_bounds())
+    assert not bounds.contains(NominalReal(5, 'm')._to_bounds())

--- a/gemd/entity/value/tests/test_normal_real.py
+++ b/gemd/entity/value/tests/test_normal_real.py
@@ -1,0 +1,10 @@
+"""Tests of the NormalReal class."""
+from gemd.entity.value.normal_real import NormalReal
+from gemd.entity.bounds import RealBounds
+
+
+def test_contains():
+    """Test that bounds know if a Value is contained within it."""
+    bounds = RealBounds(1, 3, 'm')
+    assert bounds.contains(NormalReal(300, 10, 'cm').to_bounds())
+    assert not bounds.contains(NormalReal(5, 0.1, 'm').to_bounds())

--- a/gemd/entity/value/tests/test_normal_real.py
+++ b/gemd/entity/value/tests/test_normal_real.py
@@ -6,5 +6,5 @@ from gemd.entity.bounds import RealBounds
 def test_contains():
     """Test that bounds know if a Value is contained within it."""
     bounds = RealBounds(1, 3, 'm')
-    assert bounds.contains(NormalReal(300, 10, 'cm').to_bounds())
-    assert not bounds.contains(NormalReal(5, 0.1, 'm').to_bounds())
+    assert bounds.contains(NormalReal(300, 10, 'cm')._to_bounds())
+    assert not bounds.contains(NormalReal(5, 0.1, 'm')._to_bounds())

--- a/gemd/entity/value/tests/test_smiles.py
+++ b/gemd/entity/value/tests/test_smiles.py
@@ -3,6 +3,7 @@ import pytest
 
 from gemd.json import dumps, loads
 from gemd.entity.value.smiles_value import Smiles
+from gemd.entity.bounds import MolecularStructureBounds
 
 
 def test_json():
@@ -29,3 +30,10 @@ def test_invalid_smiles():
     """
     with pytest.raises(TypeError):
         Smiles({"Al": 2, "O": 3})
+
+
+def test_contains():
+    """Test that bounds know if a Value is contained within it."""
+    bounds = MolecularStructureBounds()
+    smiles = Smiles("c1(C=O)cc(OC)c(O)cc1")
+    assert bounds.contains(smiles.to_bounds())

--- a/gemd/entity/value/tests/test_smiles.py
+++ b/gemd/entity/value/tests/test_smiles.py
@@ -36,4 +36,4 @@ def test_contains():
     """Test that bounds know if a Value is contained within it."""
     bounds = MolecularStructureBounds()
     smiles = Smiles("c1(C=O)cc(OC)c(O)cc1")
-    assert bounds.contains(smiles.to_bounds())
+    assert bounds.contains(smiles._to_bounds())

--- a/gemd/entity/value/tests/test_uniform_integer.py
+++ b/gemd/entity/value/tests/test_uniform_integer.py
@@ -28,5 +28,5 @@ def test_bounds_are_integers():
 def test_contains():
     """Test that bounds know if a Value is contained within it."""
     bounds = IntegerBounds(1, 3)
-    assert bounds.contains(UniformInteger(1, 2).to_bounds())
-    assert not bounds.contains(UniformInteger(3, 5).to_bounds())
+    assert bounds.contains(UniformInteger(1, 2)._to_bounds())
+    assert not bounds.contains(UniformInteger(3, 5)._to_bounds())

--- a/gemd/entity/value/tests/test_uniform_integer.py
+++ b/gemd/entity/value/tests/test_uniform_integer.py
@@ -2,6 +2,7 @@
 import pytest
 
 from gemd.entity.value.uniform_integer import UniformInteger
+from gemd.entity.bounds import IntegerBounds
 
 
 def test_bounds_order():
@@ -22,3 +23,10 @@ def test_bounds_are_integers():
         UniformInteger(5.7, 10)
     with pytest.raises(TypeError):
         UniformInteger(1, "five")
+
+
+def test_contains():
+    """Test that bounds know if a Value is contained within it."""
+    bounds = IntegerBounds(1, 3)
+    assert bounds.contains(UniformInteger(1, 2).to_bounds())
+    assert not bounds.contains(UniformInteger(3, 5).to_bounds())

--- a/gemd/entity/value/tests/test_uniform_real.py
+++ b/gemd/entity/value/tests/test_uniform_real.py
@@ -2,6 +2,7 @@
 import pytest
 
 from gemd.entity.value.uniform_real import UniformReal
+from gemd.entity.bounds import RealBounds
 
 
 def test_bounds_order():
@@ -22,3 +23,11 @@ def test_equality():
     assert value1 != value2
     assert value1 != value3
     assert value1 != 0.5
+
+
+def test_contains():
+    """Test that bounds know if a Value is contained within it."""
+    bounds = RealBounds(1, 3, 'm')
+    assert bounds.contains(UniformReal(100, 200, 'cm').to_bounds())
+    assert not bounds.contains(UniformReal(3, 5, 'm').to_bounds())
+    assert not bounds.contains(UniformReal(1, 3, '').to_bounds())

--- a/gemd/entity/value/tests/test_uniform_real.py
+++ b/gemd/entity/value/tests/test_uniform_real.py
@@ -28,6 +28,6 @@ def test_equality():
 def test_contains():
     """Test that bounds know if a Value is contained within it."""
     bounds = RealBounds(1, 3, 'm')
-    assert bounds.contains(UniformReal(100, 200, 'cm').to_bounds())
-    assert not bounds.contains(UniformReal(3, 5, 'm').to_bounds())
-    assert not bounds.contains(UniformReal(1, 3, '').to_bounds())
+    assert bounds.contains(UniformReal(100, 200, 'cm')._to_bounds())
+    assert not bounds.contains(UniformReal(3, 5, 'm')._to_bounds())
+    assert not bounds.contains(UniformReal(1, 3, '')._to_bounds())

--- a/gemd/entity/value/uniform_integer.py
+++ b/gemd/entity/value/uniform_integer.py
@@ -62,7 +62,7 @@ class UniformInteger(IntegerValue):
                                                                       self.lower_bound))
         self._upper_bound = int(upper_bound)
 
-    def to_bounds(self) -> IntegerBounds:
+    def _to_bounds(self) -> IntegerBounds:
         """
         Return the smallest bounds object that is consistent with the Value.
 

--- a/gemd/entity/value/uniform_integer.py
+++ b/gemd/entity/value/uniform_integer.py
@@ -1,5 +1,6 @@
 """A uniformly distributed integer value."""
 from gemd.entity.value.integer_value import IntegerValue
+from gemd.entity.bounds import IntegerBounds
 
 
 class UniformInteger(IntegerValue):
@@ -60,3 +61,16 @@ class UniformInteger(IntegerValue):
                 "upper_bound ({}) must be >= lower_bound ({})".format(upper_bound,
                                                                       self.lower_bound))
         self._upper_bound = int(upper_bound)
+
+    def to_bounds(self) -> IntegerBounds:
+        """
+        Return the smallest bounds object that is consistent with the Value.
+
+        Returns
+        -------
+        IntegerBounds
+            The minimally consistent
+            :class:`bounds <gemd.entity.bounds.integer_bounds.IntegerBounds>`.
+
+        """
+        return IntegerBounds(lower_bound=self.lower_bound, upper_bound=self.upper_bound)

--- a/gemd/entity/value/uniform_real.py
+++ b/gemd/entity/value/uniform_real.py
@@ -1,5 +1,6 @@
 """A uniformly distributed real value."""
 from gemd.entity.value.continuous_value import ContinuousValue
+from gemd.entity.bounds import RealBounds
 
 
 class UniformReal(ContinuousValue):
@@ -32,3 +33,18 @@ class UniformReal(ContinuousValue):
         self.upper_bound = upper_bound
         assert lower_bound <= upper_bound, \
             "the lower bound must be <= the upper bound"
+
+    def to_bounds(self) -> RealBounds:
+        """
+        Return the smallest bounds object that is consistent with the Value.
+
+        Returns
+        -------
+        RealBounds
+            The minimally consistent
+            :class:`bounds <gemd.entity.bounds.real_bounds.RealBounds>`.
+
+        """
+        return RealBounds(lower_bound=self.lower_bound,
+                          upper_bound=self.upper_bound,
+                          default_units=self.units)

--- a/gemd/entity/value/uniform_real.py
+++ b/gemd/entity/value/uniform_real.py
@@ -34,7 +34,7 @@ class UniformReal(ContinuousValue):
         assert lower_bound <= upper_bound, \
             "the lower bound must be <= the upper bound"
 
-    def to_bounds(self) -> RealBounds:
+    def _to_bounds(self) -> RealBounds:
         """
         Return the smallest bounds object that is consistent with the Value.
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='gemd',
-      version='0.15.0',
+      version='0.16.0',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',


### PR DESCRIPTION
In order to support SDK work around template generation and local validations, this PR provides a mechanism for testing consistency between Values and Bounds.

The explicit calls `to_bounds` seems a little less elegant than implicitly supporting them in the Bounds `contains` methods, but that would have required a little more iter-object awareness than seemed appropriate without discussion.  If that seems like the more prudent route, ading the appropriate methods would be straight forward.