### PR TITLE
Corrected repeats in flatmap

### DIFF
--- a/gemd/util/impl.py
+++ b/gemd/util/impl.py
@@ -209,30 +209,21 @@ def recursive_flatmap(obj, func, seen=None, unidirectional=True):
             return res
         else:
             seen.add(obj)
+    if isinstance(obj, BaseEntity):
+        res.extend(func(obj))
 
     if isinstance(obj, (list, tuple)):
         for i, x in enumerate(obj):
-            if isinstance(x, BaseEntity):
-                res.extend(recursive_flatmap(x, func, seen, unidirectional))
-                res.extend(func(x))
-            else:
-                res.extend(recursive_flatmap(x, func, seen, unidirectional))
+            res.extend(recursive_flatmap(x, func, seen, unidirectional))
     elif isinstance(obj, dict):
         for x in concatv(obj.keys(), obj.values()):
-            if isinstance(x, BaseEntity):
-                res.extend(recursive_flatmap(x, func, seen, unidirectional))
-                res.extend(func(x))
-            else:
-                res.extend(recursive_flatmap(x, func, seen, unidirectional))
+            res.extend(recursive_flatmap(x, func, seen, unidirectional))
     elif isinstance(obj, DictSerializable):
         for k, x in sorted(obj.__dict__.items()):
             if unidirectional and isinstance(obj, BaseEntity) and k in obj.skip:
                 continue
-            if isinstance(x, BaseEntity):
-                res.extend(recursive_flatmap(x, func, seen, unidirectional))
-                res.extend(func(x))
-            else:
-                res.extend(recursive_flatmap(x, func, seen, unidirectional))
+            res.extend(recursive_flatmap(x, func, seen, unidirectional))
+
     return res
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='gemd',
-      version='0.16.0',
+      version='0.16.1',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',


### PR DESCRIPTION
Because recursive_flatmap was executing the analysis function after return from the deep recursion, objects that appear more than once in a structure were included multiple times in the map.  This occurred for the ProcessRun-MaterialSpec square (two instances of ProcessSpec) and for AttributeTemplates that appeared in both an Attribute and a ObjectTemplates.