### PR TITLE
codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# More details are here: https://help.github.com/articles/about-codeowners/
+
+# The '*' pattern is global owners.
+
+*  @CitrineInformatics/gemd-pr-reviewers

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import subprocess
 
 
 setup(name='gemd',
-      version='0.17.1',
+      version='0.17.2',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',


### PR DESCRIPTION
same codeowners group that we are using for gemd-docs for now. 