### PR TITLE
Update required pint, as per PLA-7139

### DIFF
--- a/gemd/units/tests/test_parser.py
+++ b/gemd/units/tests/test_parser.py
@@ -19,7 +19,8 @@ def test_parse_expected():
         "g/cm^3", "g/mL", "kg/cm^3",
         _ureg("kg").u,
         "amu",  # A line that was edited
-        "Seconds"  # Added support for some title-case units
+        "Seconds",  # Added support for some title-case units
+        "delta_Celsius / hour"  # Added to make sure pint version is right (>0.10)
     ]
     for unit in expected:
         parse_units(unit)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 toolz==0.10.0
-pint==0.9
+pint==0.10
 sphinx==2.2.0
 sphinxcontrib-apidoc==0.3.0
 deprecation==2.0.7

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='0.17.3',
+      version='0.17.4',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',
@@ -21,7 +21,7 @@ setup(name='gemd',
       install_requires=[
           "toolz",
           "pytest>=4.3",
-          "pint>=0.9",
+          "pint>=0.10",
           "deprecation>=2.0.7,<3"
       ],
       classifiers=[


### PR DESCRIPTION
Minimum allowable version of pint had been pegged to the last Python-3.5-compliant version, which we no longer support.  v0.10.0 introduced a different system for parsing delta_ units, which underlay PLA-7139.