### PR TITLE
Added import support for make_index through gemd.util

### DIFF
--- a/gemd/util/__init__.py
+++ b/gemd/util/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa
-from .impl import set_uuids, substitute_links, substitute_objects, flatten, recursive_foreach, \
-    recursive_flatmap, writable_sort_order
+from .impl import set_uuids, make_index, substitute_links, substitute_objects, flatten, \
+    recursive_foreach, recursive_flatmap, writable_sort_order

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='0.17.6',
+      version='0.17.7',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',


### PR DESCRIPTION
In adding the `make_index` method, we did not add an import statement for gemd/util/__init__.py, making its import different than its compatriots.  Fixing this gap.