### PR TITLE
Remove `mas` from unit abbreviations

### DIFF
--- a/gemd/units/citrine_en.txt
+++ b/gemd/units/citrine_en.txt
@@ -172,7 +172,7 @@ turn = 2 * π * radian = _ = revolution = cycle = circle = Turn = Revolution = C
 degree = π / 180 * radian = deg = arcdeg = arcdegree = angular_degree = Degree = Deg = Arcdeg = Arcdegree = Angular_Degree
 arcminute = degree / 60 = arcmin = arc_minute = angular_minute = Arcminute = Arc_Minute = Angular_Minute
 arcsecond = arcminute / 60 = arcsec = arc_second = angular_second = Arcsecond = Arc_Second = Angular_Second
-milliarcsecond = 1e-3 * arcsecond = mas = Milliarcsecond
+milliarcsecond = 1e-3 * arcsecond = Milliarcsecond
 grade = π / 200 * radian = grad = gon = Grade
 mil = π / 32000 * radian = Mil
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='0.17.8',
+      version='0.17.9',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',
@@ -30,4 +30,4 @@ setup(name='gemd',
           'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',
       ],
-)
+      )


### PR DESCRIPTION
As per PLA-7408, `milliarcseconds` had the abbreviation `mas`.  When combined with `parse_units` being insensitive to trailing `%` or `s` (allowing `miles` to match `mile`), this meant that the unit `mass %` was being interpreted as `milliarcseconds`.  As an easy fix, we are removing `mas` from the synonym list.