### PR TITLE
Add inch-pounds to default unit set

### DIFF
--- a/gemd/units/citrine_en.txt
+++ b/gemd/units/citrine_en.txt
@@ -352,6 +352,7 @@ centimeter_H2O = centimeter * water * g_0 = cmH2O = cm_H2O
 # Torque
 [torque] = [force] * [length]
 foot_pound = foot * force_pound = ft_lb = footpound
+inch_pound = inch * force_pound = in_lb = inchpound
 
 # Viscosity
 [viscosity] = [pressure] * [time]

--- a/gemd/units/tests/test_parser.py
+++ b/gemd/units/tests/test_parser.py
@@ -46,6 +46,13 @@ def test_parse_none():
     assert parse_units(None) is None
 
 
+def test_conversion():
+    """Tests that check if particular units are interoperable."""
+    conversions = {"in_lb": "foot_pound"}
+    for source, dest in conversions.items():
+        assert convert_units(convert_units(1, source, dest), dest, source) == 1
+
+
 @contextmanager
 def _change_units(filename):
     try:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.0.1',
+      version='1.0.2',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',


### PR DESCRIPTION
As per [PLA-7928](https://citrine.atlassian.net/browse/PLA-7928), adding inch-pounds as a unit for torque.