### PR TITLE
Migrate arguments for from_entity

### DIFF
--- a/gemd/entity/link_by_uid.py
+++ b/gemd/entity/link_by_uid.py
@@ -1,5 +1,6 @@
 """A unique id that stands in for a data object."""
 import uuid
+from warnings import warn
 
 from gemd.entity.dict_serializable import DictSerializable
 
@@ -28,16 +29,24 @@ class LinkByUID(DictSerializable):
         return str({"scope": self.scope, "id": self.id})
 
     @classmethod
-    def from_entity(cls, entity, name="auto"):
+    def from_entity(cls, entity, name=None, *, scope=None):
         """
-        Create LinkByUID from in-memory object using id with scope 'name'.
+        Create LinkByUID from in-memory object.
+
+        - If there exists an id with scope (default 'auto'), the LinkByUID object will be built
+          with that scope.
+        - If there is no id with scope, an arbitrary scope-id pair will be chosen.
+        - If the object has no uids, the object will be mutated to include a uid (UUID4) with the
+          chosen scope and the LinkByUID object will be built with that scope and id.
 
         Parameters
         ----------
         entity: BaseEntity
             The entity to substitute with a LinkByUID
-        name: str, optional
-            The scope of the id.
+        name: str, optional (Deprecated)
+            The desired scope of the id.
+        scope: str, optional
+            The desired scope of the id.
 
         Returns
         -------
@@ -45,10 +54,21 @@ class LinkByUID(DictSerializable):
             A link object that references `entity` through its scope and id.
 
         """
-        if name in entity.uids:
-            scope, uid = name, entity.uids[name]
+        if name is None:
+            if scope is None:
+                scope = "auto"  # set default
+        elif scope is None:
+            warn("The positional argument 'name' is deprecated.  When selecting a default scope, "
+                 "use the 'scope' keyword argument.", DeprecationWarning)
+            scope = name
+        else:
+            if scope is not None:
+                raise ValueError("Specify the 'name' parameter or 'scope' parameter, not both.")
+
+        if scope in entity.uids:
+            uid = entity.uids[scope]
         else:
             if not entity.uids:
-                entity.add_uid(name, str(uuid.uuid4()))
+                entity.add_uid(scope, str(uuid.uuid4()))
             scope, uid = next((s, i) for s, i in entity.uids.items())
         return LinkByUID(scope, uid)

--- a/gemd/entity/tests/test_link_by_uid.py
+++ b/gemd/entity/tests/test_link_by_uid.py
@@ -1,8 +1,8 @@
 """General tests of LinkByUID dynamics."""
+import pytest
+
 from gemd.json import dumps, loads
-from gemd.entity.object.material_run import MaterialRun
-from gemd.entity.object.process_run import ProcessRun
-from gemd.entity.object.ingredient_run import IngredientRun
+from gemd.entity.object import MaterialRun, ProcessRun, IngredientRun
 from gemd.entity.link_by_uid import LinkByUID
 
 
@@ -11,7 +11,28 @@ def test_link_by_uid():
     root = MaterialRun(name='root', process=ProcessRun(name='root proc'))
     leaf = MaterialRun(name='leaf', process=ProcessRun(name='leaf proc'))
     IngredientRun(process=root.process, material=leaf)
-    IngredientRun(process=root.process, material=LinkByUID.from_entity(leaf))
+    IngredientRun(process=root.process, material=LinkByUID.from_entity(leaf, scope='id'))
 
     copy = loads(dumps(root))
     assert copy.process.ingredients[0].material == copy.process.ingredients[1].material
+
+
+def test_from_entity():
+    """Test permutations of LinkByUID.from_entity arguments."""
+    run = MaterialRun(name='leaf', process=ProcessRun(name='leaf proc'))
+    assert LinkByUID.from_entity(run).scope == 'auto'
+    assert LinkByUID.from_entity(run, scope='missing').scope == 'auto'
+    assert len(run.uids) == 1
+
+    run.uids['foo'] = 'bar'
+    link1 = LinkByUID.from_entity(run, scope='foo')
+    assert (link1.scope, link1.id) == ('foo', 'bar')
+
+    with pytest.deprecated_call():
+        assert LinkByUID.from_entity(run, 'foo').scope == 'foo'
+
+    with pytest.deprecated_call():
+        assert LinkByUID.from_entity(run, name='foo').scope == 'foo'
+
+    with pytest.raises(ValueError):
+        LinkByUID.from_entity(run, name='scope1', scope='scope2')

--- a/gemd/util/tests/test_substitute_links.py
+++ b/gemd/util/tests/test_substitute_links.py
@@ -47,12 +47,12 @@ def test_native_id_substitution():
 
     # Turn the material pointer into a LinkByUID using native_id
     subbed = substitute_links(meas, native_uid=native_id)
-    assert subbed.material == LinkByUID.from_entity(mat, name=native_id)
+    assert subbed.material == LinkByUID.from_entity(mat, scope=native_id)
 
     # Put the measurement into a list and convert that into a LinkByUID using native_id
     measurements_list = [meas]
     subbed = substitute_links(measurements_list, native_uid=native_id)
-    assert subbed == [LinkByUID.from_entity(meas, name=native_id)]
+    assert subbed == [LinkByUID.from_entity(meas, scope=native_id)]
 
 
 def test_object_key_substitution():
@@ -64,12 +64,12 @@ def test_object_key_substitution():
 
     subbed = substitute_links(process_dict, native_uid='auto')
     for key, value in subbed.items():
-        assert key == LinkByUID.from_entity(spec, name='auto')
-        assert LinkByUID.from_entity(run1, name='auto') in value
+        assert key == LinkByUID.from_entity(spec, scope='auto')
+        assert LinkByUID.from_entity(run1, scope='auto') in value
         assert LinkByUID.from_entity(run2) in value
 
     reverse_process_dict = {run2: spec}
     subbed = substitute_links(reverse_process_dict, native_uid='auto')
     for key, value in subbed.items():
         assert key == LinkByUID.from_entity(run2)
-        assert value == LinkByUID.from_entity(spec, name='auto')
+        assert value == LinkByUID.from_entity(spec, scope='auto')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.0.2',
+      version='1.1.0',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',


### PR DESCRIPTION
In light of 
* the policy around positional arguments
* the original design choice of including the `name` argument to create the `scope` attribute of a LinkByUID
* the lack of documentation of how the `from_entity` method works

this PR adds a `scope` argument and deprecates both the use of a positional argument and use of the `name` keyword for building a `LinkByUID.from_entity()`.

Unanswered here is if there should be a clever means for changing default scope from `auto` to `id` in the case where gemd-python has been imported by citrine-python.  Historically, the answer was no to avoid the surprising behavior of an import changing a behavior; but I do not believe that was discussed in depth.