### PR TITLE
Changed tuple or list to iterable

### DIFF
--- a/gemd/util/impl.py
+++ b/gemd/util/impl.py
@@ -356,7 +356,7 @@ def recursive_flatmap(obj: Union[List, Tuple, Dict, BaseEntity, DictSerializable
         elif isinstance_reversible(this):
             queue.extend(reversed(this))  # Preserve order of the list/tuple
         elif isinstance_iterable(this):
-            queue.extend(this)  # Preserve order of the list/tuple
+            queue.extend(this)  # No control over order
 
     return res
 

--- a/gemd/util/tests/test_flatten.py
+++ b/gemd/util/tests/test_flatten.py
@@ -98,3 +98,24 @@ def test_recursive_flatmap_maintains_order():
     p2 = ProcessSpec(name="two")
     orig = [p1, p2]
     assert [x.name for x in orig] == recursive_flatmap(orig, lambda x: [x.name])
+
+
+def test_more_iterable_types():
+    """Verify recursive_flatmap behaves for additional iterable types."""
+    obj = MaterialRun("foo", tags=["1", "2", "3"])
+
+    assert "1" in obj.tags
+    res = recursive_flatmap({obj}, lambda x: [x.tags.pop(0)])
+    assert "1" in res
+    assert "1" not in obj.tags
+
+    dct = {obj: obj}
+    assert "2" in obj.tags
+    res = recursive_flatmap(dct.keys(), lambda x: [x.tags.pop(0)])
+    assert "2" in res
+    assert "2" not in obj.tags
+
+    assert "3" in obj.tags
+    res = recursive_flatmap(dct.values(), lambda x: [x.tags.pop(0)])
+    assert "3" in res
+    assert "3" not in obj.tags

--- a/gemd/util/tests/test_foreach.py
+++ b/gemd/util/tests/test_foreach.py
@@ -28,3 +28,20 @@ def test_recursive_foreach():
                 "property_template"
                 ]
     assert sorted(types) == sorted(expected)
+
+
+def test_more_iterable_types():
+    obj = MaterialRun("foo", tags=["1", "2", "3"])
+
+    assert "1" in obj.tags
+    recursive_foreach({obj}, lambda x: x.tags.remove("1"))
+    assert "1" not in obj.tags
+
+    dct = {obj: obj}
+    assert "2" in obj.tags
+    recursive_foreach(dct.keys(), lambda x: x.tags.remove("2"))
+    assert "2" not in obj.tags
+
+    assert "3" in obj.tags
+    recursive_foreach(dct.values(), lambda x: x.tags.remove("3"))
+    assert "3" not in obj.tags

--- a/gemd/util/tests/test_foreach.py
+++ b/gemd/util/tests/test_foreach.py
@@ -31,6 +31,7 @@ def test_recursive_foreach():
 
 
 def test_more_iterable_types():
+    """Verify recursive_foreach behaves for additional iterable types."""
     obj = MaterialRun("foo", tags=["1", "2", "3"])
 
     assert "1" in obj.tags

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.2.0',
+      version='1.2.1',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Max Hutchinson',


### PR DESCRIPTION
Friction has been observed where `recursive_foreach` and `recursive_flatmap` behave badly on list-like elements such as dist_keys.  This corrects those methods behavior.