### PR TITLE
Non-null allowed_names and _labels

### DIFF
--- a/gemd/entity/template/process_template.py
+++ b/gemd/entity/template/process_template.py
@@ -72,9 +72,8 @@ class ProcessTemplate(BaseTemplate, HasConditionTemplates, HasParameterTemplates
 
     @allowed_names.setter
     def allowed_names(self, allowed_names):
-        # if none, leave as none; don't set to the empty set
         if allowed_names is None:
-            self._allowed_names = allowed_names
+            self._allowed_names = validate_list([], str)
         else:
             self._allowed_names = validate_list(allowed_names, str)
 
@@ -85,8 +84,7 @@ class ProcessTemplate(BaseTemplate, HasConditionTemplates, HasParameterTemplates
 
     @allowed_labels.setter
     def allowed_labels(self, allowed_labels):
-        # if none, leave as none; don't set to the empty set
         if allowed_labels is None:
-            self._allowed_labels = allowed_labels
+            self._allowed_labels = validate_list([], str)
         else:
             self._allowed_labels = validate_list(allowed_labels, str)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.2.2',
+      version='1.2.3',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Citrine Informatics',


### PR DESCRIPTION
[The docs](https://citrineinformatics.github.io/gemd-docs/specification/object-templates/#process-template) specify that the default state for `allowed_names` and `allowed_labels` for Process Templates is supposed to be the empty set, rather than an explicit None.  This PR brings this behavior into line with the docs and with the backend implementation.
