### PR TITLE
Add all_dependencies method to Base Entities

### DIFF
--- a/gemd/entity/attribute/base_attribute.py
+++ b/gemd/entity/attribute/base_attribute.py
@@ -6,7 +6,7 @@ from gemd.entity.setters import validate_list
 from gemd.entity.file_link import FileLink
 from gemd.entity.link_by_uid import LinkByUID
 
-from typing import Union, Collection, List, Optional, Type
+from typing import Optional, Union, Iterable, List, Type
 from abc import abstractmethod
 
 
@@ -34,12 +34,14 @@ class BaseAttribute(DictSerializable):
 
     """
 
-    def __init__(self, name: str, *,
+    def __init__(self,
+                 name: str,
+                 *,
                  template: Union[AttributeTemplate, LinkByUID, None] = None,
                  origin: Union[Origin, str] = Origin.UNKNOWN,
-                 value: Optional[BaseValue] = None,
+                 value: BaseValue = None,
                  notes: str = None,
-                 file_links: Union[Collection[FileLink], FileLink, None] = None):
+                 file_links: Optional[Union[Iterable[FileLink], FileLink]] = None):
         self.name = name
         self.notes = notes
 
@@ -59,7 +61,7 @@ class BaseAttribute(DictSerializable):
         return self._value
 
     @value.setter
-    def value(self, value: Optional[BaseValue]):
+    def value(self, value: BaseValue):
         if value is None:
             self._value = None
         elif isinstance(value, (BaseValue, str, bool)):
@@ -68,12 +70,12 @@ class BaseAttribute(DictSerializable):
             raise TypeError("value must be a BaseValue, string or bool: {}".format(value))
 
     @property
-    def template(self) -> Union[AttributeTemplate, LinkByUID, None]:
+    def template(self) -> Optional[Union[AttributeTemplate, LinkByUID]]:
         """Get template."""
         return self._template
 
     @template.setter
-    def template(self, template: Union[AttributeTemplate, LinkByUID, None]):
+    def template(self, template: Optional[Union[AttributeTemplate, LinkByUID]]):
         if template is None:
             self._template = None
         elif isinstance(template, (self._template_type(), LinkByUID)):
@@ -104,5 +106,5 @@ class BaseAttribute(DictSerializable):
         return self._file_links
 
     @file_links.setter
-    def file_links(self, file_links: Union[Collection[FileLink], FileLink, None]):
+    def file_links(self, file_links: Optional[Union[Iterable[FileLink], FileLink]]):
         self._file_links = validate_list(file_links, FileLink)

--- a/gemd/entity/attribute/property_and_conditions.py
+++ b/gemd/entity/attribute/property_and_conditions.py
@@ -1,7 +1,12 @@
 from gemd.entity.attribute.condition import Condition
 from gemd.entity.attribute.property import Property
+from gemd.entity.template.property_template import PropertyTemplate
+from gemd.entity.value.base_value import BaseValue
 from gemd.entity.dict_serializable import DictSerializable
+from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.setters import validate_list
+
+from typing import Optional, Union, Iterable, List
 
 
 class PropertyAndConditions(DictSerializable):
@@ -21,50 +26,50 @@ class PropertyAndConditions(DictSerializable):
 
     typ = "property_and_conditions"
 
-    def __init__(self, property=None, conditions=None):
+    def __init__(self, property: Property = None, conditions: Iterable[Condition] = None):
         self._property = None
         self.property = property
         self._conditions = None
         self.conditions = conditions
 
     @property
-    def conditions(self):
+    def conditions(self) -> List[Condition]:
         """Get conditions."""
         return self._conditions
 
     @conditions.setter
-    def conditions(self, conditions):
+    def conditions(self, conditions: Iterable[Condition]):
         self._conditions = validate_list(conditions, Condition)
 
     # Horrible hacks to make templates work in the short term
     @property
-    def name(self):
+    def name(self) -> str:
         """Get name of attribute (use name of property)."""
         return self.property.name
 
     @property
-    def template(self):
+    def template(self) -> Optional[Union[PropertyTemplate, LinkByUID]]:
         """Get template of attribute (use template of property)."""
         return self.property.template
 
     @property
-    def origin(self):
+    def origin(self) -> str:
         """Get origin of attribute (use origin of property)."""
         return self.property.origin
 
     @property
-    def value(self):
+    def value(self) -> BaseValue:
         """Get value of attribute (use value of property)."""
         return self.property.value
 
     # NOTE: this definition must go last, or else it overrides the property decorator
     @property
-    def property(self):
+    def property(self) -> Property:
         """Get property."""
         return self._property
 
     @property.setter
-    def property(self, value):
+    def property(self, value: Property):
         if isinstance(value, Property):
             self._property = value
         else:

--- a/gemd/entity/base_entity.py
+++ b/gemd/entity/base_entity.py
@@ -108,7 +108,7 @@ class BaseEntity(DictSerializable):
         return LinkByUID(scope=scope, id=uid)
 
     @abstractmethod
-    def all_dependences(self) -> 'Set[BaseEntity]':
+    def all_dependencies(self) -> 'Set[BaseEntity]':
         """Return a set of all immediate dependencies (no recursion)."""
 
     @staticmethod

--- a/gemd/entity/base_entity.py
+++ b/gemd/entity/base_entity.py
@@ -1,5 +1,6 @@
 """Base class for all entities."""
-from typing import Optional
+from abc import abstractmethod
+from typing import Optional, Set
 
 from gemd.entity.dict_serializable import DictSerializable
 from gemd.entity.case_insensitive_dict import CaseInsensitiveDict
@@ -104,6 +105,10 @@ class BaseEntity(DictSerializable):
             raise ValueError(f"{type(self)} {self.name} has no uid with scope {scope}.")
 
         return LinkByUID(scope=scope, id=uid)
+
+    @abstractmethod
+    def all_dependences(self) -> 'Set[BaseEntity]':
+        """Return a set of all immediate dependencies (no recursion)."""
 
     # Note that this could violate transitivity -- Link(scope1) == obj == Link(scope2)
     def __eq__(self, other):

--- a/gemd/entity/base_entity.py
+++ b/gemd/entity/base_entity.py
@@ -1,10 +1,10 @@
 """Base class for all entities."""
 from abc import abstractmethod
-from typing import Optional, Dict, Set, FrozenSet
-from collections.abc import Collection
+from typing import Optional, Iterable, List, Set, FrozenSet, Mapping, Dict
 
 from gemd.entity.dict_serializable import DictSerializable
 from gemd.entity.case_insensitive_dict import CaseInsensitiveDict
+from gemd.entity.setters import validate_list
 
 
 class BaseEntity(DictSerializable):
@@ -26,7 +26,7 @@ class BaseEntity(DictSerializable):
 
     typ = "base"
 
-    def __init__(self, uids, tags):
+    def __init__(self, uids: Mapping[str, str], tags: Iterable[str]):
         self._tags = None
         self.tags = tags
 
@@ -34,34 +34,29 @@ class BaseEntity(DictSerializable):
         self.uids = uids
 
     @property
-    def tags(self):
+    def tags(self) -> List[str]:
         """Get the tags."""
         return self._tags
 
     @tags.setter
-    def tags(self, tags):
-        if tags is None:
-            self._tags = []
-        elif isinstance(tags, list):
-            self._tags = tags
-        else:
-            self._tags = [tags]
+    def tags(self, tags: Iterable[str]):
+        self._tags = validate_list(tags, str)
 
     @property
-    def uids(self):
+    def uids(self) -> Mapping[str, str]:
         """Get the uids."""
         return self._uids
 
     @uids.setter
-    def uids(self, uids):
+    def uids(self, uids: Mapping[str, str]):
         if uids is None:
             self._uids = CaseInsensitiveDict()
-        elif isinstance(uids, dict):
+        elif isinstance(uids, Mapping):
             self._uids = CaseInsensitiveDict(**uids)
         else:
             self._uids = CaseInsensitiveDict(**{uids[0]: uids[1]})
 
-    def add_uid(self, scope, uid):
+    def add_uid(self, scope: str, uid: str):
         """
         Add a uid.
 
@@ -108,7 +103,7 @@ class BaseEntity(DictSerializable):
         return LinkByUID(scope=scope, id=uid)
 
     @abstractmethod
-    def all_dependencies(self) -> 'Set[BaseEntity]':
+    def all_dependencies(self) -> Set['BaseEntity']:
         """Return a set of all immediate dependencies (no recursion)."""
 
     @staticmethod
@@ -151,7 +146,7 @@ class BaseEntity(DictSerializable):
                 if BaseEntity._cached_equals(this_value, that_value, cache=cache) is False:
                     cache[cache_key] = False  # Mark as failed
                     return False
-            elif isinstance(this_value, Collection) and isinstance(that_value, Collection) \
+            elif isinstance(this_value, Iterable) and isinstance(that_value, Iterable) \
                     and not isinstance(this_value, str) and not isinstance(that_value, str):
                 # Necessary to maintain context for recursive parts of the structure
                 this_list = list(this_value)

--- a/gemd/entity/has_dependencies.py
+++ b/gemd/entity/has_dependencies.py
@@ -1,0 +1,11 @@
+"""For entities that have dependencies."""
+from abc import ABC, abstractmethod
+from typing import Union, Set
+
+
+class HasDependencies(ABC):
+    """Mix-in trait for objects that reference other objects."""
+
+    @abstractmethod
+    def _local_dependencies(self) -> Set[Union["BaseEntity", "LinkByUID"]]:
+        """All dependencies (objects) that this class introduces."""

--- a/gemd/entity/object/base_object.py
+++ b/gemd/entity/object/base_object.py
@@ -69,30 +69,22 @@ class BaseObject(BaseEntity):
     def file_links(self, file_links):
         self._file_links = validate_list(file_links, FileLink)
 
-    def all_dependences(self):
+    def all_dependencies(self):
         """Return a set of all immediate dependencies (no recursion)."""
         from gemd.entity.object.has_parameters import HasParameters
         from gemd.entity.object.has_conditions import HasConditions
         from gemd.entity.object.has_properties import HasProperties
+        from gemd.entity.object.has_spec import HasSpec
         from gemd.entity.object.has_template import HasTemplate
 
-        from gemd.entity.object import IngredientRun, MaterialRun, MeasurementRun, ProcessRun
+        from gemd.entity.object import IngredientRun, MaterialRun, MeasurementRun # no ProcessRun
         from gemd.entity.object import IngredientSpec, MaterialSpec  # no ProcessSpec
 
         result = set()
 
-        if isinstance(self, HasParameters):
-            for attr in self.parameters:
-                if attr.template is not None:
-                    result.add(attr.template)
-        if isinstance(self, HasConditions):
-            for attr in self.conditions:
-                if attr.template is not None:
-                    result.add(attr.template)
-        if isinstance(self, HasProperties):
-            for attr in self.properties:
-                if attr.template is not None:
-                    result.add(attr.template)
+        for typ in (HasParameters, HasConditions, HasProperties, HasSpec, HasTemplate):
+            if isinstance(self, typ):
+                result |= typ.all_dependencies(self)
         if isinstance(self, MaterialSpec):  # is structured inconsistently
             for attr in self.properties:
                 if attr.property.template is not None:
@@ -101,12 +93,6 @@ class BaseObject(BaseEntity):
                     if condition.template is not None:
                         result.add(condition.template)
 
-        if isinstance(self, HasTemplate):
-            if self.template is not None:
-                result.add(self.template)
-        if isinstance(self, (IngredientRun, MaterialRun, MeasurementRun, ProcessRun)):
-            if self.spec is not None:
-                result.add(self.spec)
         if isinstance(self, (IngredientRun, IngredientSpec, MeasurementRun)):
             if self.material is not None:
                 result.add(self.material)

--- a/gemd/entity/object/base_object.py
+++ b/gemd/entity/object/base_object.py
@@ -4,6 +4,8 @@ from gemd.entity.base_entity import BaseEntity
 from gemd.entity.file_link import FileLink
 from gemd.entity.setters import validate_list, validate_str
 
+from typing import Optional, Union, Iterable, List, Set, Mapping
+
 
 class BaseObject(BaseEntity):
     """
@@ -30,7 +32,13 @@ class BaseObject(BaseEntity):
 
     """
 
-    def __init__(self, name, *, uids=None, tags=None, notes=None, file_links=None):
+    def __init__(self,
+                 name: str,
+                 *,
+                 uids: Mapping[str, str] = None,
+                 tags: Iterable[str] = None,
+                 notes: str = None,
+                 file_links: Optional[Union[Iterable[FileLink], FileLink]] = None):
         BaseEntity.__init__(self, uids, tags)
         self.notes = notes
         self._name = None
@@ -52,24 +60,24 @@ class BaseObject(BaseEntity):
         return prop is None or prop.fset is not None
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Get name."""
         return self._name
 
     @name.setter
-    def name(self, name):
+    def name(self, name: str):
         self._name = validate_str(name)
 
     @property
-    def file_links(self):
+    def file_links(self) -> List[FileLink]:
         """Get file links."""
         return self._file_links
 
     @file_links.setter
-    def file_links(self, file_links):
+    def file_links(self, file_links: Union[Iterable[FileLink], FileLink]):
         self._file_links = validate_list(file_links, FileLink)
 
-    def all_dependencies(self):
+    def all_dependencies(self) -> Set[BaseEntity]:
         """Return a set of all immediate dependencies (no recursion)."""
         from gemd.entity.object.has_parameters import HasParameters
         from gemd.entity.object.has_conditions import HasConditions

--- a/gemd/entity/object/base_object.py
+++ b/gemd/entity/object/base_object.py
@@ -54,3 +54,50 @@ class BaseObject(BaseEntity):
     @file_links.setter
     def file_links(self, file_links):
         self._file_links = validate_list(file_links, FileLink)
+
+    def all_dependences(self):
+        """Return a set of all immediate dependencies (no recursion)."""
+        from gemd.entity.object.has_parameters import HasParameters
+        from gemd.entity.object.has_conditions import HasConditions
+        from gemd.entity.object.has_properties import HasProperties
+        from gemd.entity.object.has_template import HasTemplate
+
+        from gemd.entity.object import IngredientRun, MaterialRun, MeasurementRun, ProcessRun
+        from gemd.entity.object import IngredientSpec, MaterialSpec  # no ProcessSpec
+
+        result = set()
+
+        if isinstance(self, HasParameters):
+            for attr in self.parameters:
+                if attr.template is not None:
+                    result.add(attr.template)
+        if isinstance(self, HasConditions):
+            for attr in self.conditions:
+                if attr.template is not None:
+                    result.add(attr.template)
+        if isinstance(self, HasProperties):
+            for attr in self.properties:
+                if attr.template is not None:
+                    result.add(attr.template)
+        if isinstance(self, MaterialSpec):  # is structured inconsistently
+            for attr in self.properties:
+                if attr.property.template is not None:
+                    result.add(attr.property.template)
+                for condition in attr.conditions:
+                    if condition.template is not None:
+                        result.add(condition.template)
+
+        if isinstance(self, HasTemplate):
+            if self.template is not None:
+                result.add(self.template)
+        if isinstance(self, (IngredientRun, MaterialRun, MeasurementRun, ProcessRun)):
+            if self.spec is not None:
+                result.add(self.spec)
+        if isinstance(self, (IngredientRun, IngredientSpec, MeasurementRun)):
+            if self.material is not None:
+                result.add(self.material)
+        if isinstance(self, (IngredientRun, IngredientSpec, MaterialRun, MaterialSpec)):
+            if self.process is not None:
+                result.add(self.process)
+
+        return result

--- a/gemd/entity/object/has_conditions.py
+++ b/gemd/entity/object/has_conditions.py
@@ -1,12 +1,12 @@
 """For entities that have conditions."""
+from gemd.entity.has_dependencies import HasDependencies
 from gemd.entity.attribute.condition import Condition
-from gemd.entity.template.condition_template import ConditionTemplate
 from gemd.entity.setters import validate_list
 
-from typing import Iterable, List, Set
+from typing import Union, Iterable, List, Set
 
 
-class HasConditions(object):
+class HasConditions(HasDependencies):
     """Mixin-trait for entities that include conditions.
 
     Parameters
@@ -30,6 +30,6 @@ class HasConditions(object):
         """Set the list of conditions."""
         self._conditions = validate_list(conditions, Condition)
 
-    def all_dependencies(self) -> Set[ConditionTemplate]:
+    def _local_dependencies(self) -> Set[Union["BaseEntity", "LinkByUID"]]:
         """Return a set of all immediate dependencies (no recursion)."""
         return {cond.template for cond in self.conditions if cond.template is not None}

--- a/gemd/entity/object/has_conditions.py
+++ b/gemd/entity/object/has_conditions.py
@@ -24,4 +24,9 @@ class HasConditions(object):
 
     @conditions.setter
     def conditions(self, conditions):
+        """Set the list of conditions."""
         self._conditions = validate_list(conditions, Condition)
+
+    def all_dependencies(self):
+        """Return a set of all immediate dependencies (no recursion)."""
+        return {cond.template for cond in self.conditions if cond.template is not None}

--- a/gemd/entity/object/has_conditions.py
+++ b/gemd/entity/object/has_conditions.py
@@ -1,6 +1,9 @@
 """For entities that have conditions."""
 from gemd.entity.attribute.condition import Condition
+from gemd.entity.template.condition_template import ConditionTemplate
 from gemd.entity.setters import validate_list
+
+from typing import Iterable, List, Set
 
 
 class HasConditions(object):
@@ -13,20 +16,20 @@ class HasConditions(object):
 
     """
 
-    def __init__(self, conditions):
+    def __init__(self, conditions: Iterable[Condition]):
         self._conditions = None
         self.conditions = conditions
 
     @property
-    def conditions(self):
+    def conditions(self) -> List[Condition]:
         """Get a list of the conditions."""
         return self._conditions
 
     @conditions.setter
-    def conditions(self, conditions):
+    def conditions(self, conditions: Iterable[Condition]):
         """Set the list of conditions."""
         self._conditions = validate_list(conditions, Condition)
 
-    def all_dependencies(self):
+    def all_dependencies(self) -> Set[ConditionTemplate]:
         """Return a set of all immediate dependencies (no recursion)."""
         return {cond.template for cond in self.conditions if cond.template is not None}

--- a/gemd/entity/object/has_material.py
+++ b/gemd/entity/object/has_material.py
@@ -1,0 +1,25 @@
+"""For entities that have specs."""
+from gemd.entity.has_dependencies import HasDependencies
+from gemd.entity.object.base_object import BaseObject
+from gemd.entity.link_by_uid import LinkByUID
+
+from abc import abstractmethod
+from typing import Union, Set
+
+
+class HasMaterial(HasDependencies):
+    """Mix-in trait for objects that can be assigned materials."""
+
+    @property
+    @abstractmethod
+    def material(self) -> Union[BaseObject, LinkByUID]:
+        """Get the material."""
+
+    @material.setter
+    @abstractmethod
+    def material(self, spec: Union[BaseObject, LinkByUID]):
+        """Set the material."""
+
+    def _local_dependencies(self) -> Set[Union["BaseEntity", "LinkByUID"]]:
+        """Return a set of all immediate dependencies (no recursion)."""
+        return {self.material} if self.material is not None else set()

--- a/gemd/entity/object/has_parameters.py
+++ b/gemd/entity/object/has_parameters.py
@@ -1,6 +1,9 @@
 """For entities that have parameters."""
 from gemd.entity.attribute.parameter import Parameter
+from gemd.entity.template.parameter_template import ParameterTemplate
 from gemd.entity.setters import validate_list
+
+from typing import Iterable, List, Set
 
 
 class HasParameters(object):
@@ -13,20 +16,20 @@ class HasParameters(object):
 
     """
 
-    def __init__(self, parameters):
+    def __init__(self, parameters: Iterable[Parameter]):
         self._parameters = None
         self.parameters = parameters
 
     @property
-    def parameters(self):
+    def parameters(self) -> List[Parameter]:
         """Get the list of parameters."""
         return self._parameters
 
     @parameters.setter
-    def parameters(self, parameters):
+    def parameters(self, parameters: Iterable[Parameter]):
         """Set the list of parameters."""
         self._parameters = validate_list(parameters, Parameter)
 
-    def all_dependencies(self):
+    def all_dependencies(self) -> Set[ParameterTemplate]:
         """Return a set of all immediate dependencies (no recursion)."""
         return {param.template for param in self.parameters if param.template is not None}

--- a/gemd/entity/object/has_parameters.py
+++ b/gemd/entity/object/has_parameters.py
@@ -24,4 +24,9 @@ class HasParameters(object):
 
     @parameters.setter
     def parameters(self, parameters):
+        """Set the list of parameters."""
         self._parameters = validate_list(parameters, Parameter)
+
+    def all_dependencies(self):
+        """Return a set of all immediate dependencies (no recursion)."""
+        return {param.template for param in self.parameters if param.template is not None}

--- a/gemd/entity/object/has_parameters.py
+++ b/gemd/entity/object/has_parameters.py
@@ -1,12 +1,12 @@
 """For entities that have parameters."""
+from gemd.entity.has_dependencies import HasDependencies
 from gemd.entity.attribute.parameter import Parameter
-from gemd.entity.template.parameter_template import ParameterTemplate
 from gemd.entity.setters import validate_list
 
-from typing import Iterable, List, Set
+from typing import Union, Iterable, List, Set
 
 
-class HasParameters(object):
+class HasParameters(HasDependencies):
     """Mixin-trait for entities that include parameters.
 
     Parameters
@@ -30,6 +30,6 @@ class HasParameters(object):
         """Set the list of parameters."""
         self._parameters = validate_list(parameters, Parameter)
 
-    def all_dependencies(self) -> Set[ParameterTemplate]:
+    def _local_dependencies(self) -> Set[Union["BaseEntity", "LinkByUID"]]:
         """Return a set of all immediate dependencies (no recursion)."""
         return {param.template for param in self.parameters if param.template is not None}

--- a/gemd/entity/object/has_process.py
+++ b/gemd/entity/object/has_process.py
@@ -1,0 +1,25 @@
+"""For entities that have specs."""
+from gemd.entity.has_dependencies import HasDependencies
+from gemd.entity.object.base_object import BaseObject
+from gemd.entity.link_by_uid import LinkByUID
+
+from abc import abstractmethod
+from typing import Union, Set
+
+
+class HasProcess(HasDependencies):
+    """Mix-in trait for objects that can be assigned materials."""
+
+    @property
+    @abstractmethod
+    def process(self) -> Union[BaseObject, LinkByUID]:
+        """Get the process."""
+
+    @process.setter
+    @abstractmethod
+    def process(self, process: Union[BaseObject, LinkByUID]):
+        """Set the process."""
+
+    def _local_dependencies(self) -> Set[Union["BaseEntity", "LinkByUID"]]:
+        """Return a set of all immediate dependencies (no recursion)."""
+        return {self.process} if self.process is not None else set()

--- a/gemd/entity/object/has_properties.py
+++ b/gemd/entity/object/has_properties.py
@@ -1,12 +1,12 @@
 """For entities that have properties."""
+from gemd.entity.has_dependencies import HasDependencies
 from gemd.entity.attribute.property import Property
-from gemd.entity.template.property_template import PropertyTemplate
 from gemd.entity.setters import validate_list
 
-from typing import Iterable, List, Set
+from typing import Union, Iterable, List, Set
 
 
-class HasProperties(object):
+class HasProperties(HasDependencies):
     """Mixin-trait for entities that include properties.
 
     Parameters
@@ -30,6 +30,6 @@ class HasProperties(object):
         """Set the list of properties."""
         self._properties = validate_list(properties, Property)
 
-    def all_dependencies(self) -> Set[PropertyTemplate]:
+    def _local_dependencies(self) -> Set[Union["BaseEntity", "LinkByUID"]]:
         """Return a set of all immediate dependencies (no recursion)."""
         return {prop.template for prop in self.properties if prop.template is not None}

--- a/gemd/entity/object/has_properties.py
+++ b/gemd/entity/object/has_properties.py
@@ -1,6 +1,9 @@
 """For entities that have properties."""
 from gemd.entity.attribute.property import Property
+from gemd.entity.template.property_template import PropertyTemplate
 from gemd.entity.setters import validate_list
+
+from typing import Iterable, List, Set
 
 
 class HasProperties(object):
@@ -13,20 +16,20 @@ class HasProperties(object):
 
     """
 
-    def __init__(self, properties):
+    def __init__(self, properties: Iterable[Property]):
         self._properties = None
         self.properties = properties
 
     @property
-    def properties(self):
+    def properties(self) -> List[Property]:
         """Get a list of the properties."""
         return self._properties
 
     @properties.setter
-    def properties(self, properties):
+    def properties(self, properties: Iterable[Property]):
         """Set the list of properties."""
         self._properties = validate_list(properties, Property)
 
-    def all_dependencies(self):
+    def all_dependencies(self) -> Set[PropertyTemplate]:
         """Return a set of all immediate dependencies (no recursion)."""
         return {prop.template for prop in self.properties if prop.template is not None}

--- a/gemd/entity/object/has_properties.py
+++ b/gemd/entity/object/has_properties.py
@@ -24,4 +24,9 @@ class HasProperties(object):
 
     @properties.setter
     def properties(self, properties):
+        """Set the list of properties"""
         self._properties = validate_list(properties, Property)
+
+    def all_dependencies(self):
+        """Return a set of all immediate dependencies (no recursion)."""
+        return {prop.template for prop in self.properties if prop.template is not None}

--- a/gemd/entity/object/has_quantities.py
+++ b/gemd/entity/object/has_quantities.py
@@ -26,8 +26,10 @@ class HasQuantities(object):
     """
 
     def __init__(self, *,
-                 mass_fraction=None, volume_fraction=None, number_fraction=None,
-                 absolute_quantity=None):
+                 mass_fraction: ContinuousValue = None,
+                 volume_fraction: ContinuousValue = None,
+                 number_fraction: ContinuousValue = None,
+                 absolute_quantity: ContinuousValue = None):
 
         self._mass_fraction = None
         self.mass_fraction = mass_fraction
@@ -42,12 +44,12 @@ class HasQuantities(object):
         self.absolute_quantity = absolute_quantity
 
     @property
-    def mass_fraction(self):
+    def mass_fraction(self) -> ContinuousValue:
         """Get mass fraction."""
         return self._mass_fraction
 
     @mass_fraction.setter
-    def mass_fraction(self, mass_fraction):
+    def mass_fraction(self, mass_fraction: ContinuousValue):
         if mass_fraction is None:
             self._mass_fraction = None
         elif not isinstance(mass_fraction, ContinuousValue):
@@ -56,12 +58,12 @@ class HasQuantities(object):
             self._mass_fraction = mass_fraction
 
     @property
-    def volume_fraction(self):
+    def volume_fraction(self) -> ContinuousValue:
         """Get volume fraction."""
         return self._volume_fraction
 
     @volume_fraction.setter
-    def volume_fraction(self, volume_fraction):
+    def volume_fraction(self, volume_fraction: ContinuousValue):
         if volume_fraction is None:
             self._volume_fraction = None
         elif not isinstance(volume_fraction, ContinuousValue):
@@ -70,12 +72,12 @@ class HasQuantities(object):
             self._volume_fraction = volume_fraction
 
     @property
-    def number_fraction(self):
+    def number_fraction(self) -> ContinuousValue:
         """Get number fraction."""
         return self._number_fraction
 
     @number_fraction.setter
-    def number_fraction(self, number_fraction):
+    def number_fraction(self, number_fraction: ContinuousValue):
         if number_fraction is None:
             self._number_fraction = None
         elif not isinstance(number_fraction, ContinuousValue):
@@ -84,12 +86,12 @@ class HasQuantities(object):
             self._number_fraction = number_fraction
 
     @property
-    def absolute_quantity(self):
+    def absolute_quantity(self) -> ContinuousValue:
         """Get absolute quantity."""
         return self._absolute_quantity
 
     @absolute_quantity.setter
-    def absolute_quantity(self, absolute_quantity):
+    def absolute_quantity(self, absolute_quantity: ContinuousValue):
         if absolute_quantity is None:
             self._absolute_quantity = None
         elif isinstance(absolute_quantity, ContinuousValue):

--- a/gemd/entity/object/has_source.py
+++ b/gemd/entity/object/has_source.py
@@ -13,20 +13,20 @@ class HasSource(object):
 
     """
 
-    def __init__(self, source):
+    def __init__(self, source: PerformedSource):
         self._source = None
         self.source = source
 
     @property
-    def source(self):
+    def source(self) -> PerformedSource:
         """Get the list of parameters."""
         return self._source
 
     @source.setter
-    def source(self, value):
+    def source(self, value: PerformedSource):
         if value is None:
             self._source = None
         elif isinstance(value, PerformedSource):
             self._source = value
         else:
-            raise TypeError("Source must be a PerformedSource; was {}".format(type(value)))
+            raise TypeError(f"Source must be a PerformedSource; was {type(value)}")

--- a/gemd/entity/object/has_spec.py
+++ b/gemd/entity/object/has_spec.py
@@ -50,3 +50,7 @@ class HasSpec(object):
             return self.spec.template
         else:
             return None
+
+    def all_dependencies(self):
+        """Return a set of all immediate dependencies (no recursion)."""
+        return {self.spec} if self.spec is not None else set()

--- a/gemd/entity/object/has_spec.py
+++ b/gemd/entity/object/has_spec.py
@@ -1,0 +1,52 @@
+"""For entities that have templates."""
+from gemd.entity.object.has_template import HasTemplate
+from gemd.entity.template.base_template import BaseTemplate
+from gemd.entity.link_by_uid import LinkByUID
+
+from abc import abstractmethod
+from typing import Optional, Union, Type
+
+
+class HasSpec(object):
+    """Mix-in trait for objects that can be assigned specs.
+
+    Parameters
+    ----------
+    spec: :class:`Has_Template <gemd.entity.object.has_template.Has_Template>`
+        A spec, which expresses the anticipated or aspirational behavior of this object.
+
+    """
+
+    def __init__(self, spec: Union[HasTemplate, LinkByUID] = None):
+        self._spec = None
+        self.spec = spec
+
+    @property
+    def spec(self) -> Union[HasTemplate, LinkByUID]:
+        """Get the spec."""
+        return self._spec
+
+    @spec.setter
+    @abstractmethod
+    def spec(self, spec: Union[HasTemplate, LinkByUID]):
+        """Set the spec."""
+        if spec is None:
+            self._spec = None
+        elif isinstance(spec, (self._spec_type(), LinkByUID)):
+            self._spec = spec
+        else:
+            raise TypeError(f"Template must be a {self._spec_type()} or LinkByUID, "
+                            f"not {type(spec)}")
+
+    @staticmethod
+    @abstractmethod
+    def _spec_type() -> Type:
+        """Child must report implementation details."""
+
+    @property
+    def template(self) -> Optional[Union[BaseTemplate, LinkByUID]]:
+        """Get the template associated with the spec."""
+        if isinstance(self.spec, HasTemplate):
+            return self.spec.template
+        else:
+            return None

--- a/gemd/entity/object/has_spec.py
+++ b/gemd/entity/object/has_spec.py
@@ -1,10 +1,11 @@
 """For entities that have specs."""
+from gemd.entity.object.base_object import BaseObject
 from gemd.entity.object.has_template import HasTemplate
 from gemd.entity.template.base_template import BaseTemplate
 from gemd.entity.link_by_uid import LinkByUID
 
 from abc import abstractmethod
-from typing import Optional, Union, Type
+from typing import Optional, Union, Set, Type
 
 
 class HasSpec(object):
@@ -50,6 +51,6 @@ class HasSpec(object):
         else:
             return None
 
-    def all_dependencies(self):
+    def all_dependencies(self) -> Set[BaseObject]:
         """Return a set of all immediate dependencies (no recursion)."""
         return {self.spec} if self.spec is not None else set()

--- a/gemd/entity/object/has_spec.py
+++ b/gemd/entity/object/has_spec.py
@@ -1,5 +1,5 @@
 """For entities that have specs."""
-from gemd.entity.object.base_object import BaseObject
+from gemd.entity.has_dependencies import HasDependencies
 from gemd.entity.object.has_template import HasTemplate
 from gemd.entity.template.base_template import BaseTemplate
 from gemd.entity.link_by_uid import LinkByUID
@@ -8,7 +8,7 @@ from abc import abstractmethod
 from typing import Optional, Union, Set, Type
 
 
-class HasSpec(object):
+class HasSpec(HasDependencies):
     """Mix-in trait for objects that can be assigned specs.
 
     Parameters
@@ -51,6 +51,6 @@ class HasSpec(object):
         else:
             return None
 
-    def all_dependencies(self) -> Set[BaseObject]:
+    def _local_dependencies(self) -> Set[Union["BaseEntity", "LinkByUID"]]:
         """Return a set of all immediate dependencies (no recursion)."""
         return {self.spec} if self.spec is not None else set()

--- a/gemd/entity/object/has_template.py
+++ b/gemd/entity/object/has_template.py
@@ -2,6 +2,9 @@
 from gemd.entity.template.base_template import BaseTemplate
 from gemd.entity.link_by_uid import LinkByUID
 
+from abc import abstractmethod
+from typing import Optional, Union, Type
+
 
 class HasTemplate(object):
     """Mix-in trait for objects that can be assigned templates.
@@ -13,20 +16,28 @@ class HasTemplate(object):
 
     """
 
-    def __init__(self, template=None):
+    def __init__(self, template: Optional[Union[BaseTemplate, LinkByUID]] = None):
         self._template = None
         self.template = template
 
+    @staticmethod
+    @abstractmethod
+    def _template_type() -> Type:
+        """Child must report implementation details."""
+
     @property
-    def template(self):
+    def template(self) -> Optional[Union[BaseTemplate, LinkByUID]]:
         """Get the template."""
         return self._template
 
     @template.setter
-    def template(self, template):
+    @abstractmethod
+    def template(self, template: Optional[Union[BaseTemplate, LinkByUID]]):
+        """Set the template."""
         if template is None:
             self._template = None
-        elif isinstance(template, (BaseTemplate, LinkByUID)):
+        elif isinstance(template, (self._template_type(), LinkByUID)):
             self._template = template
         else:
-            raise TypeError("Template must be a template or LinkByUID: {}".format(template))
+            raise TypeError(f"Template must be a {self._template_type()} or LinkByUID, "
+                            f"not {type(template)}")

--- a/gemd/entity/object/has_template.py
+++ b/gemd/entity/object/has_template.py
@@ -1,4 +1,5 @@
 """For entities that have templates."""
+from gemd.entity.has_dependencies import HasDependencies
 from gemd.entity.template.base_template import BaseTemplate
 from gemd.entity.link_by_uid import LinkByUID
 
@@ -6,7 +7,7 @@ from abc import abstractmethod
 from typing import Optional, Union, Set, Type
 
 
-class HasTemplate(object):
+class HasTemplate(HasDependencies):
     """Mix-in trait for objects that can be assigned templates.
 
     Parameters
@@ -31,7 +32,6 @@ class HasTemplate(object):
         return self._template
 
     @template.setter
-    @abstractmethod
     def template(self, template: Optional[Union[BaseTemplate, LinkByUID]]):
         """Set the template."""
         if template is None:
@@ -42,6 +42,6 @@ class HasTemplate(object):
             raise TypeError(f"Template must be a {self._template_type()} or LinkByUID, "
                             f"not {type(template)}")
 
-    def all_dependencies(self) -> Set[BaseTemplate]:
+    def _local_dependencies(self) -> Set[Union["BaseEntity", "LinkByUID"]]:
         """Return a set of all immediate dependencies (no recursion)."""
         return {self.template} if self.template is not None else set()

--- a/gemd/entity/object/has_template.py
+++ b/gemd/entity/object/has_template.py
@@ -41,3 +41,7 @@ class HasTemplate(object):
         else:
             raise TypeError(f"Template must be a {self._template_type()} or LinkByUID, "
                             f"not {type(template)}")
+
+    def all_dependencies(self):
+        """Return a set of all immediate dependencies (no recursion)."""
+        return {self.template} if self.template is not None else set()

--- a/gemd/entity/object/has_template.py
+++ b/gemd/entity/object/has_template.py
@@ -3,7 +3,7 @@ from gemd.entity.template.base_template import BaseTemplate
 from gemd.entity.link_by_uid import LinkByUID
 
 from abc import abstractmethod
-from typing import Optional, Union, Type
+from typing import Optional, Union, Set, Type
 
 
 class HasTemplate(object):
@@ -42,6 +42,6 @@ class HasTemplate(object):
             raise TypeError(f"Template must be a {self._template_type()} or LinkByUID, "
                             f"not {type(template)}")
 
-    def all_dependencies(self):
+    def all_dependencies(self) -> Set[BaseTemplate]:
         """Return a set of all immediate dependencies (no recursion)."""
         return {self.template} if self.template is not None else set()

--- a/gemd/entity/object/ingredient_run.py
+++ b/gemd/entity/object/ingredient_run.py
@@ -2,6 +2,8 @@ from gemd.entity.object.ingredient_spec import IngredientSpec
 from gemd.entity.object.material_run import MaterialRun
 from gemd.entity.object.process_run import ProcessRun
 from gemd.entity.object.base_object import BaseObject
+from gemd.entity.object.has_material import HasMaterial
+from gemd.entity.object.has_process import HasProcess
 from gemd.entity.object.has_quantities import HasQuantities
 from gemd.entity.object.has_spec import HasSpec
 from gemd.entity.value.continuous_value import ContinuousValue
@@ -13,7 +15,7 @@ from gemd.entity.setters import validate_list
 from typing import Optional, Union, Iterable, List, Mapping, Type, Any
 
 
-class IngredientRun(BaseObject, HasQuantities, HasSpec):
+class IngredientRun(BaseObject, HasQuantities, HasSpec, HasMaterial, HasProcess):
     """
     An ingredient run.
 

--- a/gemd/entity/object/ingredient_run.py
+++ b/gemd/entity/object/ingredient_run.py
@@ -1,9 +1,19 @@
+from gemd.entity.object.ingredient_spec import IngredientSpec
+from gemd.entity.object.material_run import MaterialRun
+from gemd.entity.object.process_run import ProcessRun
 from gemd.entity.object.base_object import BaseObject
 from gemd.entity.object.has_quantities import HasQuantities
+from gemd.entity.object.has_spec import HasSpec
+from gemd.entity.value.continuous_value import ContinuousValue
+from gemd.entity.dict_serializable import DictSerializable
+from gemd.entity.file_link import FileLink
+from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.setters import validate_list
 
+from typing import Union, Set, List, Dict, Type
 
-class IngredientRun(BaseObject, HasQuantities):
+
+class IngredientRun(BaseObject, HasQuantities, HasSpec):
     """
     An ingredient run.
 
@@ -46,26 +56,35 @@ class IngredientRun(BaseObject, HasQuantities):
 
     typ = "ingredient_run"
 
-    def __init__(self, *, material=None, process=None, mass_fraction=None,
-                 volume_fraction=None, number_fraction=None, absolute_quantity=None,
-                 spec=None, uids=None, tags=None, notes=None, file_links=None):
+    def __init__(self,
+                 *,
+                 material: Union[MaterialRun, LinkByUID] = None,
+                 process: Union[ProcessRun, LinkByUID] = None,
+                 mass_fraction: ContinuousValue = None,
+                 volume_fraction: ContinuousValue = None,
+                 number_fraction: ContinuousValue = None,
+                 absolute_quantity: ContinuousValue = None,
+                 spec: Union[IngredientSpec, LinkByUID] = None,
+                 uids: Dict[str, str] = None,
+                 tags: Union[List[str], Set[str]] = None,
+                 notes: str = None,
+                 file_links: Union[List[FileLink], Set[FileLink]] = None):
         BaseObject.__init__(self, name=None, uids=uids, tags=tags,
                             notes=notes, file_links=file_links)
+        self._labels = None
+        HasSpec.__init__(self, spec)  # this will overwrite name/labels if/when they are set
+
         HasQuantities.__init__(self, mass_fraction=mass_fraction, volume_fraction=volume_fraction,
                                number_fraction=number_fraction, absolute_quantity=absolute_quantity
                                )
         self._material = None
         self._process = None
-        self._spec = None
-        self._labels = None
 
-        # this will overwrite name/labels if/when they are set
-        self.spec = spec
         self.material = material
         self.process = process
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Get name."""
         from gemd.entity.object.ingredient_spec import IngredientSpec
         if isinstance(self.spec, IngredientSpec):
@@ -74,7 +93,7 @@ class IngredientRun(BaseObject, HasQuantities):
             return super().name
 
     @property
-    def labels(self):
+    def labels(self) -> List[str]:
         """Get labels."""
         from gemd.entity.object.ingredient_spec import IngredientSpec
         if isinstance(self.spec, IngredientSpec):
@@ -83,14 +102,12 @@ class IngredientRun(BaseObject, HasQuantities):
             return self._labels
 
     @property
-    def material(self):
+    def material(self) -> Union[MaterialRun, LinkByUID]:
         """Get the material."""
         return self._material
 
     @material.setter
-    def material(self, material):
-        from gemd.entity.object import MaterialRun
-        from gemd.entity.link_by_uid import LinkByUID
+    def material(self, material: Union[MaterialRun, LinkByUID]):
         if material is None:
             self._material = None
         elif isinstance(material, (MaterialRun, LinkByUID)):
@@ -100,14 +117,12 @@ class IngredientRun(BaseObject, HasQuantities):
                             "LinkByUID: {}".format(material))
 
     @property
-    def process(self):
+    def process(self) -> Union[ProcessRun, LinkByUID]:
         """Get the material."""
         return self._process
 
     @process.setter
-    def process(self, process):
-        from gemd.entity.object import ProcessRun
-        from gemd.entity.link_by_uid import LinkByUID
+    def process(self, process: Union[ProcessRun, LinkByUID]):
         if isinstance(self._process, ProcessRun):
             # This could throw an exception if it's not in the list, but then something else broke
             self._process.ingredients.remove(self)
@@ -120,29 +135,27 @@ class IngredientRun(BaseObject, HasQuantities):
             raise TypeError("IngredientRun.process must be a ProcessRun or "
                             "LinkByUID: {}".format(process))
 
+    @staticmethod
+    def _spec_type() -> Type:
+        """Required method to satisfy HasTemplates mix-in."""
+        return IngredientSpec
+
     @property
-    def spec(self):
-        """Get the ingredient spec."""
-        return self._spec
+    def spec(self) -> Union[IngredientSpec, LinkByUID]:
+        """Get the spec."""
+        return super().spec
 
     @spec.setter
-    def spec(self, spec):
-        from gemd.entity.object.ingredient_spec import IngredientSpec
-        from gemd.entity.link_by_uid import LinkByUID
-
-        if isinstance(self._spec, IngredientSpec):  # Store values if you had them
+    def spec(self, spec: Union[IngredientSpec, LinkByUID]):
+        """Set the spec."""
+        if isinstance(self.spec, IngredientSpec):  # Store values if you had them
             self._name = self.spec.name
             self._labels = validate_list(self.spec.labels, str)
-
-        if spec is None:
-            self._spec = None
-        elif isinstance(spec, (IngredientSpec, LinkByUID)):
-            self._spec = spec
-        else:
-            raise TypeError("spec must be a IngredientSpec or LinkByUID: {}".format(spec))
+        # Note that the super() mechanism does not work properly for overloaded setters
+        getattr(HasSpec, "spec").fset(self, spec)
 
     @classmethod
-    def from_dict(cls, d):
+    def from_dict(cls, d: Dict) -> DictSerializable:
         """
         Overloaded method from DictSerializable to intercept `name` and `labels` fields.
 

--- a/gemd/entity/object/ingredient_run.py
+++ b/gemd/entity/object/ingredient_run.py
@@ -10,7 +10,7 @@ from gemd.entity.file_link import FileLink
 from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.setters import validate_list
 
-from typing import Union, Set, List, Dict, Type
+from typing import Optional, Union, Iterable, List, Mapping, Type, Any
 
 
 class IngredientRun(BaseObject, HasQuantities, HasSpec):
@@ -65,10 +65,10 @@ class IngredientRun(BaseObject, HasQuantities, HasSpec):
                  number_fraction: ContinuousValue = None,
                  absolute_quantity: ContinuousValue = None,
                  spec: Union[IngredientSpec, LinkByUID] = None,
-                 uids: Dict[str, str] = None,
-                 tags: Union[List[str], Set[str]] = None,
+                 uids: Mapping[str, str] = None,
+                 tags: Iterable[str] = None,
                  notes: str = None,
-                 file_links: Union[List[FileLink], Set[FileLink]] = None):
+                 file_links: Optional[Union[Iterable[FileLink], FileLink]] = None):
         BaseObject.__init__(self, name=None, uids=uids, tags=tags,
                             notes=notes, file_links=file_links)
         self._labels = None
@@ -155,7 +155,7 @@ class IngredientRun(BaseObject, HasQuantities, HasSpec):
         getattr(HasSpec, "spec").fset(self, spec)
 
     @classmethod
-    def from_dict(cls, d: Dict) -> DictSerializable:
+    def from_dict(cls, d: Mapping[str, Any]) -> DictSerializable:
         """
         Overloaded method from DictSerializable to intercept `name` and `labels` fields.
 

--- a/gemd/entity/object/ingredient_spec.py
+++ b/gemd/entity/object/ingredient_spec.py
@@ -1,9 +1,17 @@
+from gemd.entity.object.material_spec import MaterialSpec
+from gemd.entity.object.process_spec import ProcessSpec
 from gemd.entity.object.base_object import BaseObject
 from gemd.entity.object.has_quantities import HasQuantities
+from gemd.entity.object.has_template import HasTemplate
+from gemd.entity.value.continuous_value import ContinuousValue
+from gemd.entity.file_link import FileLink
+from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.setters import validate_list
 
+from typing import Union, Set, List, Dict, Type
 
-class IngredientSpec(BaseObject, HasQuantities):
+
+class IngredientSpec(BaseObject, HasQuantities, HasTemplate):
     """
     An ingredient specification.
 
@@ -48,10 +56,20 @@ class IngredientSpec(BaseObject, HasQuantities):
 
     typ = "ingredient_spec"
 
-    def __init__(self, name, *, material=None, process=None, labels=None,
-                 mass_fraction=None, volume_fraction=None, number_fraction=None,
-                 absolute_quantity=None,
-                 uids=None, tags=None, notes=None, file_links=None):
+    def __init__(self,
+                 name: str,
+                 *,
+                 material: Union[MaterialSpec, LinkByUID] = None,
+                 process: Union[ProcessSpec, LinkByUID] = None,
+                 labels: Union[List[str], Set[str]] = None,
+                 mass_fraction: ContinuousValue = None,
+                 volume_fraction: ContinuousValue = None,
+                 number_fraction:ContinuousValue = None,
+                 absolute_quantity: ContinuousValue = None,
+                 uids: Dict[str, str] = None,
+                 tags: Union[List[str], Set[str]] = None,
+                 notes: str = None,
+                 file_links: Union[List[FileLink], Set[FileLink]] = None):
 
         BaseObject.__init__(self, name=name,
                             uids=uids, tags=tags, notes=notes, file_links=file_links)
@@ -68,23 +86,22 @@ class IngredientSpec(BaseObject, HasQuantities):
         self.process = process
 
     @property
-    def labels(self):
+    def labels(self) -> List[str]:
         """Get labels."""
         return self._labels
 
     @labels.setter
-    def labels(self, labels):
+    def labels(self, labels: Union[List[str], Set[str]]):
         self._labels = validate_list(labels, str)
 
     @property
-    def material(self):
+    def material(self) -> Union[MaterialSpec, LinkByUID]:
         """Get the material spec."""
         return self._material
 
     @material.setter
-    def material(self, material):
-        from gemd.entity.object.material_spec import MaterialSpec
-        from gemd.entity.link_by_uid import LinkByUID
+    def material(self, material: MaterialSpec):
+        """Set the material spec."""
         if material is None:
             self._material = None
         elif isinstance(material, (MaterialSpec, LinkByUID)):
@@ -93,14 +110,13 @@ class IngredientSpec(BaseObject, HasQuantities):
             raise TypeError("IngredientSpec.material must be a MaterialSpec or LinkByUID")
 
     @property
-    def process(self):
-        """Get the material."""
+    def process(self) -> Union[ProcessSpec, LinkByUID]:
+        """Get the process."""
         return self._process
 
     @process.setter
-    def process(self, process):
-        from gemd.entity.object import ProcessSpec
-        from gemd.entity.link_by_uid import LinkByUID
+    def process(self, process: Union[ProcessSpec, LinkByUID]):
+        """Set the process."""
         if isinstance(self._process, ProcessSpec):
             # This could throw an exception if it's not in the list, but then something else broke
             self._process.ingredients.remove(self)
@@ -112,3 +128,18 @@ class IngredientSpec(BaseObject, HasQuantities):
         else:
             raise TypeError("IngredientSpec.process must be a ProcessSpec or "
                             "LinkByUID: {}".format(process))
+
+    @property
+    def template(self):
+        """Ingredients do not have templates, so this method always returns None."""
+        return None
+
+    @template.setter
+    def template(self, template):
+        """Ingredients do not have templates, so this method always raises an exception."""
+        raise AttributeError("Ingredients do not support a template.")
+
+    @staticmethod
+    def _template_type() -> Type:
+        """Required method to satisfy HasTemplates mix-in."""
+        return type(None)

--- a/gemd/entity/object/ingredient_spec.py
+++ b/gemd/entity/object/ingredient_spec.py
@@ -1,6 +1,8 @@
 from gemd.entity.object.material_spec import MaterialSpec
 from gemd.entity.object.process_spec import ProcessSpec
 from gemd.entity.object.base_object import BaseObject
+from gemd.entity.object.has_material import HasMaterial
+from gemd.entity.object.has_process import HasProcess
 from gemd.entity.object.has_quantities import HasQuantities
 from gemd.entity.object.has_template import HasTemplate
 from gemd.entity.value.continuous_value import ContinuousValue
@@ -11,7 +13,7 @@ from gemd.entity.setters import validate_list
 from typing import Optional, Union, Iterable, List, Mapping, Type
 
 
-class IngredientSpec(BaseObject, HasQuantities, HasTemplate):
+class IngredientSpec(BaseObject, HasQuantities, HasTemplate, HasMaterial, HasProcess):
     """
     An ingredient specification.
 

--- a/gemd/entity/object/ingredient_spec.py
+++ b/gemd/entity/object/ingredient_spec.py
@@ -8,7 +8,7 @@ from gemd.entity.file_link import FileLink
 from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.setters import validate_list
 
-from typing import Union, Set, List, Dict, Type
+from typing import Optional, Union, Iterable, List, Mapping, Type
 
 
 class IngredientSpec(BaseObject, HasQuantities, HasTemplate):
@@ -61,15 +61,15 @@ class IngredientSpec(BaseObject, HasQuantities, HasTemplate):
                  *,
                  material: Union[MaterialSpec, LinkByUID] = None,
                  process: Union[ProcessSpec, LinkByUID] = None,
-                 labels: Union[List[str], Set[str]] = None,
+                 labels: Iterable[str] = None,
                  mass_fraction: ContinuousValue = None,
                  volume_fraction: ContinuousValue = None,
                  number_fraction: ContinuousValue = None,
                  absolute_quantity: ContinuousValue = None,
-                 uids: Dict[str, str] = None,
-                 tags: Union[List[str], Set[str]] = None,
+                 uids: Mapping[str, str] = None,
+                 tags: Iterable[str] = None,
                  notes: str = None,
-                 file_links: Union[List[FileLink], Set[FileLink]] = None):
+                 file_links: Optional[Union[Iterable[FileLink], FileLink]] = None):
 
         BaseObject.__init__(self, name=name,
                             uids=uids, tags=tags, notes=notes, file_links=file_links)
@@ -91,7 +91,7 @@ class IngredientSpec(BaseObject, HasQuantities, HasTemplate):
         return self._labels
 
     @labels.setter
-    def labels(self, labels: Union[List[str], Set[str]]):
+    def labels(self, labels: Iterable[str]):
         self._labels = validate_list(labels, str)
 
     @property
@@ -100,7 +100,7 @@ class IngredientSpec(BaseObject, HasQuantities, HasTemplate):
         return self._material
 
     @material.setter
-    def material(self, material: MaterialSpec):
+    def material(self, material: Union[MaterialSpec, LinkByUID]):
         """Set the material spec."""
         if material is None:
             self._material = None

--- a/gemd/entity/object/material_run.py
+++ b/gemd/entity/object/material_run.py
@@ -7,7 +7,7 @@ from gemd.entity.file_link import FileLink
 from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.setters import validate_list
 
-from typing import Union, Collection, Mapping, Type
+from typing import Optional, Union, Iterable, List, Mapping, Type, Any
 
 
 class MaterialRun(BaseObject, HasSpec):
@@ -60,9 +60,9 @@ class MaterialRun(BaseObject, HasSpec):
                  process: Union[ProcessRun, LinkByUID] = None,
                  sample_type: Union[SampleType, str] = "unknown",
                  uids: Mapping[str, str] = None,
-                 tags: Collection[str] = None,
+                 tags: Iterable[str] = None,
                  notes: str = None,
-                 file_links: Collection[FileLink] = None):
+                 file_links: Optional[Union[Iterable[FileLink], FileLink]] = None):
         from gemd.entity.object.measurement_run import MeasurementRun
         BaseObject.__init__(self, name=name, uids=uids, tags=tags, notes=notes,
                             file_links=file_links)
@@ -94,7 +94,7 @@ class MaterialRun(BaseObject, HasSpec):
             raise TypeError("process must be a ProcessRun or LinkByUID: {}".format(process))
 
     @property
-    def measurements(self) -> Collection["MeasurementRun"]:
+    def measurements(self) -> List["MeasurementRun"]:
         """Get a read-only list of the measurement runs."""
         return self._measurements
 
@@ -112,7 +112,7 @@ class MaterialRun(BaseObject, HasSpec):
         """Required method to satisfy HasTemplates mix-in."""
         return MaterialSpec
 
-    def _dict_for_compare(self) -> Mapping:
+    def _dict_for_compare(self) -> Mapping[str, Any]:
         """Support for recursive equals."""
         base = super()._dict_for_compare()
         base['measurements'] = self.measurements

--- a/gemd/entity/object/material_run.py
+++ b/gemd/entity/object/material_run.py
@@ -1,6 +1,7 @@
 from gemd.entity.object.material_spec import MaterialSpec
 from gemd.entity.object.process_run import ProcessRun
 from gemd.entity.object.base_object import BaseObject
+from gemd.entity.object.has_process import HasProcess
 from gemd.entity.object.has_spec import HasSpec
 from gemd.enumeration import SampleType
 from gemd.entity.file_link import FileLink
@@ -10,7 +11,7 @@ from gemd.entity.setters import validate_list
 from typing import Optional, Union, Iterable, List, Mapping, Type, Any
 
 
-class MaterialRun(BaseObject, HasSpec):
+class MaterialRun(BaseObject, HasSpec, HasProcess):
     """
     A material run.
 

--- a/gemd/entity/object/material_run.py
+++ b/gemd/entity/object/material_run.py
@@ -1,9 +1,16 @@
+from gemd.entity.object.material_spec import MaterialSpec
+from gemd.entity.object.process_run import ProcessRun
 from gemd.entity.object.base_object import BaseObject
+from gemd.entity.object.has_spec import HasSpec
 from gemd.enumeration import SampleType
+from gemd.entity.file_link import FileLink
+from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.setters import validate_list
 
+from typing import Union, Set, List, Dict, Type
 
-class MaterialRun(BaseObject):
+
+class MaterialRun(BaseObject, HasSpec):
     """
     A material run.
 
@@ -46,31 +53,35 @@ class MaterialRun(BaseObject):
 
     skip = {"_measurements"}
 
-    def __init__(self, name, *, spec=None, process=None, sample_type="unknown",
-                 uids=None, tags=None, notes=None, file_links=None):
+    def __init__(self,
+                 name: str,
+                 *,
+                 spec: Union[MaterialSpec, LinkByUID] = None,
+                 process: Union[ProcessRun, LinkByUID] = None,
+                 sample_type: Union[SampleType, str] = "unknown",
+                 uids: Dict[str, str] = None,
+                 tags: Union[List[str], Set[str]] = None,
+                 notes: str = None,
+                 file_links: Union[List[FileLink], Set[FileLink]] = None):
         from gemd.entity.object.measurement_run import MeasurementRun
-        from gemd.entity.link_by_uid import LinkByUID
 
         BaseObject.__init__(self, name=name, uids=uids, tags=tags, notes=notes,
                             file_links=file_links)
+        HasSpec.__init__(self, spec=spec)
         self._process = None
         self._measurements = validate_list(None, [MeasurementRun, LinkByUID])
         self._sample_type = None
-        self._spec = None
 
-        self.spec = spec
         self.process = process
         self.sample_type = sample_type
 
     @property
-    def process(self):
+    def process(self) -> Union[ProcessRun, LinkByUID]:
         """Get the originating process run."""
         return self._process
 
     @process.setter
-    def process(self, process):
-        from gemd.entity.object.process_run import ProcessRun
-        from gemd.entity.link_by_uid import LinkByUID
+    def process(self, process: Union[ProcessRun, LinkByUID]):
         if self.process is not None and isinstance(self.process, ProcessRun):
             self.process._output_material = None
         if process is None:
@@ -84,45 +95,25 @@ class MaterialRun(BaseObject):
             raise TypeError("process must be a ProcessRun or LinkByUID: {}".format(process))
 
     @property
-    def measurements(self):
-        """Get a list of measurement runs."""
+    def measurements(self) -> List["MeasurementRun"]:
+        """Get a read-only list of the measurement runs."""
         return self._measurements
 
     @property
-    def sample_type(self):
+    def sample_type(self) -> str:
         """Get the sample type."""
         return self._sample_type
 
     @sample_type.setter
-    def sample_type(self, sample_type):
+    def sample_type(self, sample_type: Union[SampleType, str]):
         self._sample_type = SampleType.get_value(sample_type)
 
-    @property
-    def spec(self):
-        """Get the material spec."""
-        return self._spec
+    @staticmethod
+    def _spec_type() -> Type:
+        """Required method to satisfy HasTemplates mix-in."""
+        return MaterialSpec
 
-    @spec.setter
-    def spec(self, spec):
-        from gemd.entity.object.material_spec import MaterialSpec
-        from gemd.entity.link_by_uid import LinkByUID
-        if spec is None:
-            self._spec = None
-        elif isinstance(spec, (MaterialSpec, LinkByUID)):
-            self._spec = spec
-        else:
-            raise TypeError("spec must be a MaterialSpec or LinkByUID: {}".format(spec))
-
-    @property
-    def template(self):
-        """Get the template of the spec, if applicable."""
-        from gemd.entity.object.material_spec import MaterialSpec
-        if isinstance(self.spec, MaterialSpec):
-            return self.spec.template
-        else:
-            return None
-
-    def _dict_for_compare(self):
+    def _dict_for_compare(self) -> Dict:
         """Support for recursive equals."""
         base = super()._dict_for_compare()
         base['measurements'] = self.measurements

--- a/gemd/entity/object/material_spec.py
+++ b/gemd/entity/object/material_spec.py
@@ -1,16 +1,17 @@
 from gemd.entity.attribute.property_and_conditions import PropertyAndConditions
 from gemd.entity.object.process_spec import ProcessSpec
 from gemd.entity.object.base_object import BaseObject
+from gemd.entity.object.has_process import HasProcess
 from gemd.entity.object.has_template import HasTemplate
 from gemd.entity.template.material_template import MaterialTemplate
 from gemd.entity.file_link import FileLink
 from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.setters import validate_list
 
-from typing import Optional, Union, Iterable, List, Mapping, Type
+from typing import Optional, Union, Iterable, List, Set, Mapping, Type
 
 
-class MaterialSpec(BaseObject, HasTemplate):
+class MaterialSpec(BaseObject, HasTemplate, HasProcess):
     """
     A material specification.
 
@@ -106,3 +107,14 @@ class MaterialSpec(BaseObject, HasTemplate):
     def _template_type() -> Type:
         """Communicate expected template type to parent class."""
         return MaterialTemplate
+
+    def _local_dependencies(self) -> Set[Union["BaseEntity", "LinkByUID"]]:
+        """Return a set of all immediate dependencies (no recursion)."""
+        result = set()
+        for attr in self.properties:
+            if attr.property.template is not None:
+                result.add(attr.property.template)
+            for condition in attr.conditions:
+                if condition.template is not None:
+                    result.add(condition.template)
+        return result

--- a/gemd/entity/object/material_spec.py
+++ b/gemd/entity/object/material_spec.py
@@ -7,7 +7,7 @@ from gemd.entity.file_link import FileLink
 from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.setters import validate_list
 
-from typing import Optional, Union, Set, List, Dict, Type
+from typing import Optional, Union, Iterable, List, Mapping, Type
 
 
 class MaterialSpec(BaseObject, HasTemplate):
@@ -50,12 +50,12 @@ class MaterialSpec(BaseObject, HasTemplate):
                  name: str,
                  *,
                  template: Optional[Union[MaterialTemplate, LinkByUID]] = None,
-                 properties: List[PropertyAndConditions] = None,
                  process: Union[ProcessSpec, LinkByUID] = None,
-                 uids: Dict[str, str] = None,
-                 tags: Union[List[str], Set[str]] = None,
+                 properties: Iterable[PropertyAndConditions] = None,
+                 uids: Mapping[str, str] = None,
+                 tags: Iterable[str] = None,
                  notes: str = None,
-                 file_links: Union[List[FileLink], Set[FileLink]] = None):
+                 file_links: Optional[Union[Iterable[FileLink], FileLink]] = None):
         BaseObject.__init__(self, name=name, uids=uids, tags=tags, notes=notes,
                             file_links=file_links)
         self._properties = None
@@ -70,8 +70,7 @@ class MaterialSpec(BaseObject, HasTemplate):
         return self._properties
 
     @properties.setter
-    def properties(self, properties: Union[Set[PropertyAndConditions],
-                                           List[PropertyAndConditions]]):
+    def properties(self, properties: Iterable[PropertyAndConditions]):
         self._properties = validate_list(properties, PropertyAndConditions)
 
     @property

--- a/gemd/entity/object/material_spec.py
+++ b/gemd/entity/object/material_spec.py
@@ -1,7 +1,13 @@
 from gemd.entity.attribute.property_and_conditions import PropertyAndConditions
+from gemd.entity.object.process_spec import ProcessSpec
 from gemd.entity.object.base_object import BaseObject
 from gemd.entity.object.has_template import HasTemplate
+from gemd.entity.template.material_template import MaterialTemplate
+from gemd.entity.file_link import FileLink
+from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.setters import validate_list
+
+from typing import Optional, Union, Set, List, Dict, Type
 
 
 class MaterialSpec(BaseObject, HasTemplate):
@@ -40,9 +46,16 @@ class MaterialSpec(BaseObject, HasTemplate):
 
     typ = "material_spec"
 
-    def __init__(self, name, *, template=None,
-                 properties=None, process=None, uids=None, tags=None,
-                 notes=None, file_links=None):
+    def __init__(self,
+                 name: str,
+                 *,
+                 template: Optional[Union[MaterialTemplate, LinkByUID]] = None,
+                 properties: List[PropertyAndConditions] = None,
+                 process: Union[ProcessSpec, LinkByUID] = None,
+                 uids: Dict[str, str] = None,
+                 tags: Union[List[str], Set[str]] = None,
+                 notes: str = None,
+                 file_links: Union[List[FileLink], Set[FileLink]] = None):
         BaseObject.__init__(self, name=name, uids=uids, tags=tags, notes=notes,
                             file_links=file_links)
         self._properties = None
@@ -52,21 +65,22 @@ class MaterialSpec(BaseObject, HasTemplate):
         HasTemplate.__init__(self, template)
 
     @property
-    def properties(self):
+    def properties(self) -> List[PropertyAndConditions]:
         """Get the list of property-and-conditions."""
         return self._properties
 
     @properties.setter
-    def properties(self, properties):
+    def properties(self, properties: Union[Set[PropertyAndConditions],
+                                           List[PropertyAndConditions]]):
         self._properties = validate_list(properties, PropertyAndConditions)
 
     @property
-    def process(self):
+    def process(self) -> Union[ProcessSpec, LinkByUID]:
         """Get the originating process spec."""
         return self._process
 
     @process.setter
-    def process(self, process):
+    def process(self, process: Union[ProcessSpec, LinkByUID]):
         """
         Link to the ProcessSpec that creates this MaterialSpec.
 
@@ -86,5 +100,10 @@ class MaterialSpec(BaseObject, HasTemplate):
             process._output_material = self
             self._process = process
         else:
-            raise TypeError("process must be an instance of ProcessSpec or LinkByUID; "
-                            "instead received type {}: {}".format(type(process), process))
+            raise TypeError(f"process must be an instance of ProcessSpec or LinkByUID; "
+                            f"instead received type {type(process)}: {process}")
+
+    @staticmethod
+    def _template_type() -> Type:
+        """Communicate expected template type to parent class."""
+        return MaterialTemplate

--- a/gemd/entity/object/measurement_run.py
+++ b/gemd/entity/object/measurement_run.py
@@ -1,6 +1,7 @@
 from gemd.entity.object.measurement_spec import MeasurementSpec
 from gemd.entity.object.material_run import MaterialRun
 from gemd.entity.object.base_object import BaseObject
+from gemd.entity.object.has_material import HasMaterial
 from gemd.entity.object.has_spec import HasSpec
 from gemd.entity.object.has_conditions import HasConditions
 from gemd.entity.object.has_properties import HasProperties
@@ -16,7 +17,8 @@ from gemd.entity.link_by_uid import LinkByUID
 from typing import Optional, Union, Iterable, Mapping, Type
 
 
-class MeasurementRun(BaseObject, HasSpec, HasConditions, HasProperties, HasParameters, HasSource):
+class MeasurementRun(BaseObject, HasMaterial, HasSpec, HasConditions, HasProperties,
+                     HasParameters, HasSource):
     """
     A measurement run.
 

--- a/gemd/entity/object/measurement_run.py
+++ b/gemd/entity/object/measurement_run.py
@@ -13,7 +13,7 @@ from gemd.entity.source.performed_source import PerformedSource
 from gemd.entity.file_link import FileLink
 from gemd.entity.link_by_uid import LinkByUID
 
-from typing import Union, Collection, Mapping, Type
+from typing import Optional, Union, Iterable, Mapping, Type
 
 
 class MeasurementRun(BaseObject, HasSpec, HasConditions, HasProperties, HasParameters, HasSource):
@@ -64,13 +64,13 @@ class MeasurementRun(BaseObject, HasSpec, HasConditions, HasProperties, HasParam
                  *,
                  spec: Union[MeasurementSpec, LinkByUID] = None,
                  material: Union[MaterialRun, LinkByUID] = None,
-                 properties: Collection[Property] = None,
-                 conditions: Collection[Condition] = None,
-                 parameters: Collection[Parameter] = None,
+                 properties: Iterable[Property] = None,
+                 conditions: Iterable[Condition] = None,
+                 parameters: Iterable[Parameter] = None,
                  uids: Mapping[str, str] = None,
-                 tags: Collection[str] = None,
+                 tags: Iterable[str] = None,
                  notes: str = None,
-                 file_links: Collection[FileLink] = None,
+                 file_links: Optional[Union[Iterable[FileLink], FileLink]] = None,
                  source: PerformedSource = None):
         BaseObject.__init__(self, name=name, uids=uids, tags=tags, notes=notes,
                             file_links=file_links)

--- a/gemd/entity/object/measurement_spec.py
+++ b/gemd/entity/object/measurement_spec.py
@@ -2,6 +2,13 @@ from gemd.entity.object.base_object import BaseObject
 from gemd.entity.object.has_parameters import HasParameters
 from gemd.entity.object.has_conditions import HasConditions
 from gemd.entity.object.has_template import HasTemplate
+from gemd.entity.template.measurement_template import MeasurementTemplate
+from gemd.entity.attribute.condition import Condition
+from gemd.entity.attribute.parameter import Parameter
+from gemd.entity.file_link import FileLink
+from gemd.entity.link_by_uid import LinkByUID
+
+from typing import Optional, Union, Set, List, Dict, Type
 
 
 class MeasurementSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
@@ -40,11 +47,23 @@ class MeasurementSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
 
     typ = "measurement_spec"
 
-    def __init__(self, name, *, template=None,
-                 parameters=None, conditions=None,
-                 uids=None, tags=None, notes=None, file_links=None):
+    def __init__(self,
+                 name: str,
+                 *,
+                 template: Optional[Union[MeasurementTemplate, LinkByUID]] = None,
+                 conditions: List[Condition] = None,
+                 parameters: List[Parameter] = None,
+                 uids: Dict[str, str] = None,
+                 tags: Union[List[str], Set[str]] = None,
+                 notes: str = None,
+                 file_links: Union[List[FileLink], Set[FileLink]] = None):
         BaseObject.__init__(self, name=name, uids=uids, tags=tags, notes=notes,
                             file_links=file_links)
         HasParameters.__init__(self, parameters=parameters)
         HasConditions.__init__(self, conditions=conditions)
         HasTemplate.__init__(self, template=template)
+
+    @staticmethod
+    def _template_type() -> Type:
+        """Communicate expected template type to parent class."""
+        return MeasurementTemplate

--- a/gemd/entity/object/measurement_spec.py
+++ b/gemd/entity/object/measurement_spec.py
@@ -8,7 +8,7 @@ from gemd.entity.attribute.parameter import Parameter
 from gemd.entity.file_link import FileLink
 from gemd.entity.link_by_uid import LinkByUID
 
-from typing import Optional, Union, Set, List, Dict, Type
+from typing import Optional, Union, Iterable, Mapping, Type
 
 
 class MeasurementSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
@@ -51,12 +51,12 @@ class MeasurementSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
                  name: str,
                  *,
                  template: Optional[Union[MeasurementTemplate, LinkByUID]] = None,
-                 conditions: List[Condition] = None,
-                 parameters: List[Parameter] = None,
-                 uids: Dict[str, str] = None,
-                 tags: Union[List[str], Set[str]] = None,
+                 conditions: Iterable[Condition] = None,
+                 parameters: Iterable[Parameter] = None,
+                 uids: Mapping[str, str] = None,
+                 tags: Iterable[str] = None,
                  notes: str = None,
-                 file_links: Union[List[FileLink], Set[FileLink]] = None):
+                 file_links: Optional[Union[Iterable[FileLink], FileLink]] = None):
         BaseObject.__init__(self, name=name, uids=uids, tags=tags, notes=notes,
                             file_links=file_links)
         HasParameters.__init__(self, parameters=parameters)

--- a/gemd/entity/object/process_run.py
+++ b/gemd/entity/object/process_run.py
@@ -1,11 +1,20 @@
+from gemd.entity.object.process_spec import ProcessSpec
 from gemd.entity.object.base_object import BaseObject
+from gemd.entity.object.has_spec import HasSpec
 from gemd.entity.object.has_conditions import HasConditions
 from gemd.entity.object.has_parameters import HasParameters
 from gemd.entity.object.has_source import HasSource
+from gemd.entity.attribute.condition import Condition
+from gemd.entity.attribute.parameter import Parameter
+from gemd.entity.source.performed_source import PerformedSource
+from gemd.entity.file_link import FileLink
+from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.setters import validate_list
 
+from typing import Union, Set, List, Dict, Type
 
-class ProcessRun(BaseObject, HasConditions, HasParameters, HasSource):
+
+class ProcessRun(BaseObject, HasSpec, HasConditions, HasParameters, HasSource):
     """
     A process run.
 
@@ -55,59 +64,45 @@ class ProcessRun(BaseObject, HasConditions, HasParameters, HasSource):
 
     skip = {"_output_material", "_ingredients"}
 
-    def __init__(self, name, *, spec=None,
-                 conditions=None, parameters=None,
-                 uids=None, tags=None, notes=None, file_links=None, source=None):
+    def __init__(self,
+                 name: str,
+                 *,
+                 spec: Union[ProcessSpec, LinkByUID] = None,
+                 conditions: List[Condition] = None,
+                 parameters: List[Parameter] = None,
+                 uids: Dict[str, str] = None,
+                 tags: Union[List[str], Set[str]] = None,
+                 notes: str = None,
+                 file_links: Union[List[FileLink], Set[FileLink]] = None,
+                 source: PerformedSource = None):
         from gemd.entity.object.ingredient_run import IngredientRun
-        from gemd.entity.link_by_uid import LinkByUID
 
         BaseObject.__init__(self, name=name, uids=uids, tags=tags, notes=notes,
                             file_links=file_links)
+        HasSpec.__init__(self, spec=spec)
         HasConditions.__init__(self, conditions)
         HasParameters.__init__(self, parameters)
         HasSource.__init__(self, source)
 
-        self._spec = None
-        self.spec = spec
         self._output_material = None
         self._ingredients = validate_list(None, [IngredientRun, LinkByUID])
 
     @property
-    def output_material(self):
+    def output_material(self) -> ["MaterialRun"]:
         """Get the output material run."""
         return self._output_material
 
     @property
-    def ingredients(self):
+    def ingredients(self) -> List["IngredientRun"]:
         """Get the input ingredient runs."""
         return self._ingredients
 
-    @property
-    def spec(self):
-        """Get the process spec."""
-        return self._spec
+    @staticmethod
+    def _spec_type() -> Type:
+        """Required method to satisfy HasTemplates mix-in."""
+        return ProcessSpec
 
-    @spec.setter
-    def spec(self, spec):
-        from gemd.entity.object.process_spec import ProcessSpec
-        from gemd.entity.link_by_uid import LinkByUID
-        if spec is None:
-            self._spec = None
-        elif isinstance(spec, (ProcessSpec, LinkByUID)):
-            self._spec = spec
-        else:
-            raise TypeError("spec must be a ProcessSpec or LinkByUID: {}".format(spec))
-
-    @property
-    def template(self):
-        """Get the template of the spec, if applicable."""
-        from gemd.entity.object.process_spec import ProcessSpec
-        if isinstance(self.spec, ProcessSpec):
-            return self.spec.template
-        else:
-            return None
-
-    def _dict_for_compare(self):
+    def _dict_for_compare(self) -> Dict:
         """Support for recursive equals."""
         base = super()._dict_for_compare()
         base['ingredients'] = self.ingredients

--- a/gemd/entity/object/process_run.py
+++ b/gemd/entity/object/process_run.py
@@ -11,7 +11,7 @@ from gemd.entity.file_link import FileLink
 from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.setters import validate_list
 
-from typing import Union, Collection, Mapping, Type
+from typing import Optional, Union, Iterable, List, Mapping, Dict, Type, Any
 
 
 class ProcessRun(BaseObject, HasSpec, HasConditions, HasParameters, HasSource):
@@ -68,12 +68,12 @@ class ProcessRun(BaseObject, HasSpec, HasConditions, HasParameters, HasSource):
                  name: str,
                  *,
                  spec: Union[ProcessSpec, LinkByUID] = None,
-                 conditions: Collection[Condition] = None,
-                 parameters: Collection[Parameter] = None,
+                 conditions: Iterable[Condition] = None,
+                 parameters: Iterable[Parameter] = None,
                  uids: Mapping[str, str] = None,
-                 tags: Collection[str] = None,
+                 tags: Iterable[str] = None,
                  notes: str = None,
-                 file_links: Collection[FileLink] = None,
+                 file_links: Optional[Union[Iterable[FileLink], FileLink]] = None,
                  source: PerformedSource = None):
         from gemd.entity.object.ingredient_run import IngredientRun
 
@@ -88,12 +88,12 @@ class ProcessRun(BaseObject, HasSpec, HasConditions, HasParameters, HasSource):
         self._output_material = None
 
     @property
-    def output_material(self) -> ["MaterialRun"]:
+    def output_material(self) -> Optional["MaterialRun"]:
         """Get the output material run."""
         return self._output_material
 
     @property
-    def ingredients(self) -> Collection["IngredientRun"]:
+    def ingredients(self) -> List["IngredientRun"]:
         """Get the input ingredient runs."""
         return self._ingredients
 
@@ -102,7 +102,7 @@ class ProcessRun(BaseObject, HasSpec, HasConditions, HasParameters, HasSource):
         """Required method to satisfy HasTemplates mix-in."""
         return ProcessSpec
 
-    def _dict_for_compare(self) -> Mapping:
+    def _dict_for_compare(self) -> Dict[str, Any]:
         """Support for recursive equals."""
         base = super()._dict_for_compare()
         base['ingredients'] = self.ingredients

--- a/gemd/entity/object/process_spec.py
+++ b/gemd/entity/object/process_spec.py
@@ -9,7 +9,7 @@ from gemd.entity.file_link import FileLink
 from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.setters import validate_list
 
-from typing import Optional, Union, Set, List, Dict, Type
+from typing import Optional, Union, Iterable, List, Mapping, Dict, Type, Any
 
 
 class ProcessSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
@@ -62,15 +62,15 @@ class ProcessSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
     skip = {"_output_material", "_ingredients"}
 
     def __init__(self,
-                 name,
+                 name: str,
                  *,
                  template: Optional[Union[ProcessTemplate, LinkByUID]] = None,
-                 conditions: List[Condition] = None,
-                 parameters: List[Parameter] = None,
-                 uids: Dict[str, str] = None,
-                 tags: Union[List[str], Set[str]] = None,
+                 conditions: Iterable[Condition] = None,
+                 parameters: Iterable[Parameter] = None,
+                 uids: Mapping[str, str] = None,
+                 tags: Iterable[str] = None,
                  notes: str = None,
-                 file_links: Union[List[FileLink], Set[FileLink]] = None):
+                 file_links: Optional[Union[Iterable[FileLink], FileLink]] = None):
         from gemd.entity.object.ingredient_spec import IngredientSpec
         from gemd.entity.link_by_uid import LinkByUID
 
@@ -97,11 +97,11 @@ class ProcessSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
         return self._ingredients
 
     @property
-    def output_material(self) -> "MaterialSpec":  # noqa: F821
+    def output_material(self) -> Optional["MaterialSpec"]:  # noqa: F821
         """Get the output material spec."""
         return self._output_material
 
-    def _dict_for_compare(self) -> Dict:
+    def _dict_for_compare(self) -> Dict[str, Any]:
         """Support for recursive equals."""
         base = super()._dict_for_compare()
         base['ingredients'] = self.ingredients

--- a/gemd/entity/object/process_spec.py
+++ b/gemd/entity/object/process_spec.py
@@ -2,7 +2,14 @@ from gemd.entity.object.base_object import BaseObject
 from gemd.entity.object.has_parameters import HasParameters
 from gemd.entity.object.has_conditions import HasConditions
 from gemd.entity.object.has_template import HasTemplate
+from gemd.entity.template.process_template import ProcessTemplate
+from gemd.entity.attribute.condition import Condition
+from gemd.entity.attribute.parameter import Parameter
+from gemd.entity.file_link import FileLink
+from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.setters import validate_list
+
+from typing import Optional, Union, Set, List, Dict, Type
 
 
 class ProcessSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
@@ -54,9 +61,16 @@ class ProcessSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
 
     skip = {"_output_material", "_ingredients"}
 
-    def __init__(self, name, *, template=None,
-                 parameters=None, conditions=None,
-                 uids=None, tags=None, notes=None, file_links=None):
+    def __init__(self,
+                 name,
+                 *,
+                 template: Optional[Union[ProcessTemplate, LinkByUID]] = None,
+                 conditions: List[Condition] = None,
+                 parameters: List[Parameter] = None,
+                 uids: Dict[str, str] = None,
+                 tags: Union[List[str], Set[str]] = None,
+                 notes: str = None,
+                 file_links: Union[List[FileLink], Set[FileLink]] = None):
         from gemd.entity.object.ingredient_spec import IngredientSpec
         from gemd.entity.link_by_uid import LinkByUID
 
@@ -72,17 +86,22 @@ class ProcessSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
         self._output_material = None
         self._ingredients = validate_list(None, [IngredientSpec, LinkByUID])
 
+    @staticmethod
+    def _template_type() -> Type:
+        """Communicate expected template type to parent class."""
+        return ProcessTemplate
+
     @property
-    def ingredients(self):
+    def ingredients(self) -> List["IngredientSpec"]:
         """Get the list of input ingredient specs."""
         return self._ingredients
 
     @property
-    def output_material(self):
+    def output_material(self) -> "MaterialSpec":
         """Get the output material spec."""
         return self._output_material
 
-    def _dict_for_compare(self):
+    def _dict_for_compare(self) -> Dict:
         """Support for recursive equals."""
         base = super()._dict_for_compare()
         base['ingredients'] = self.ingredients

--- a/gemd/entity/object/tests/test_ingredient_spec.py
+++ b/gemd/entity/object/tests/test_ingredient_spec.py
@@ -86,3 +86,13 @@ def test_invalid_assignment():
         IngredientSpec(name="name", process="process")
     with pytest.raises(TypeError):
         IngredientSpec()  # Name is required
+
+
+def test_bad_has_template():
+    """Make sure the non-implementation of HasTemplate behaves properly."""
+    assert isinstance(None, IngredientSpec(name="name")._template_type()), \
+        "Ingredients didn't have NoneType templates"
+    assert IngredientSpec(name="name").template is None, \
+        "An ingredient didn't have a null template."
+    with pytest.raises(AttributeError):  # Note an AttributeError, not a TypeError
+        IngredientSpec(name="name").template = 1

--- a/gemd/entity/object/tests/test_material_run.py
+++ b/gemd/entity/object/tests/test_material_run.py
@@ -149,13 +149,13 @@ def test_equality():
     assert mat5 == mat4, "Flattening removes measurement references, but that's okay"
 
 
-def test_dependences():
+def test_dependencies():
     """Test that dependency lists make sense."""
     ps = ProcessSpec(name="ps")
     pr = ProcessRun(name="pr", spec=ps)
     ms = MaterialSpec(name="ms", process=ps)
     mr = MaterialRun(name="mr", spec=ms, process=pr)
 
-    assert ps not in mr.all_dependences()
-    assert pr in mr.all_dependences()
-    assert ms in mr.all_dependences()
+    assert ps not in mr.all_dependencies()
+    assert pr in mr.all_dependencies()
+    assert ms in mr.all_dependencies()

--- a/gemd/entity/object/tests/test_material_run.py
+++ b/gemd/entity/object/tests/test_material_run.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 
 from gemd.json import loads, dumps
 from gemd.entity.attribute import PropertyAndConditions, Property
-from gemd.entity.object import MaterialRun, ProcessRun, MaterialSpec, MeasurementRun
+from gemd.entity.object import MaterialRun, ProcessSpec, ProcessRun, MaterialSpec, MeasurementRun
 from gemd.entity.template import MaterialTemplate
 from gemd.entity.value import NominalReal
 from gemd.entity.link_by_uid import LinkByUID
@@ -147,3 +147,15 @@ def test_equality():
 
     mat5 = next(x for x in flatten(mat4, 'test-scope') if isinstance(x, MaterialRun))
     assert mat5 == mat4, "Flattening removes measurement references, but that's okay"
+
+
+def test_dependences():
+    """Test that dependency lists make sense."""
+    ps = ProcessSpec(name="ps")
+    pr = ProcessRun(name="pr", spec=ps)
+    ms = MaterialSpec(name="ms", process=ps)
+    mr = MaterialRun(name="mr", spec=ms, process=pr)
+
+    assert ps not in mr.all_dependences()
+    assert pr in mr.all_dependences()
+    assert ms in mr.all_dependences()

--- a/gemd/entity/object/tests/test_material_spec.py
+++ b/gemd/entity/object/tests/test_material_spec.py
@@ -1,8 +1,12 @@
 """Tests of the material spec object."""
 import pytest
 
+from gemd.entity.attribute import PropertyAndConditions, Property, Condition
+from gemd.entity.bounds import IntegerBounds
 from gemd.entity.object.process_spec import ProcessSpec
 from gemd.entity.object.material_spec import MaterialSpec
+from gemd.entity.template import MaterialTemplate, PropertyTemplate, ConditionTemplate
+from gemd.entity.value import NominalInteger
 
 
 def test_process_reassignment():
@@ -28,3 +32,22 @@ def test_invalid_assignment():
         MaterialSpec("name", template=MaterialSpec("another spec"))
     with pytest.raises(TypeError):
         MaterialSpec()  # Name is required
+
+
+def test_dependences():
+    """Test that dependency lists make sense."""
+    prop = PropertyTemplate(name="name", bounds=IntegerBounds(0, 1))
+    cond = ConditionTemplate(name="name", bounds=IntegerBounds(0, 1))
+
+    template = MaterialTemplate("measurement template")
+    spec = MaterialSpec("A spec", template=template,
+                        properties=[PropertyAndConditions(
+                            property=Property("name", template=prop, value=NominalInteger(1)),
+                            conditions=[
+                                Condition("name", template=cond, value=NominalInteger(1))
+                            ]
+                        )])
+
+    assert template in spec.all_dependences()
+    assert cond in spec.all_dependences()
+    assert prop in spec.all_dependences()

--- a/gemd/entity/object/tests/test_material_spec.py
+++ b/gemd/entity/object/tests/test_material_spec.py
@@ -34,7 +34,7 @@ def test_invalid_assignment():
         MaterialSpec()  # Name is required
 
 
-def test_dependences():
+def test_dependencies():
     """Test that dependency lists make sense."""
     prop = PropertyTemplate(name="name", bounds=IntegerBounds(0, 1))
     cond = ConditionTemplate(name="name", bounds=IntegerBounds(0, 1))
@@ -48,6 +48,6 @@ def test_dependences():
                             ]
                         )])
 
-    assert template in spec.all_dependences()
-    assert cond in spec.all_dependences()
-    assert prop in spec.all_dependences()
+    assert template in spec.all_dependencies()
+    assert cond in spec.all_dependencies()
+    assert prop in spec.all_dependencies()

--- a/gemd/entity/object/tests/test_measurement_run.py
+++ b/gemd/entity/object/tests/test_measurement_run.py
@@ -138,7 +138,7 @@ def test_template_access():
     assert meas.template is None
 
 
-def test_dependences():
+def test_dependencies():
     """Test that dependency lists make sense."""
     prop = PropertyTemplate(name="name", bounds=IntegerBounds(0, 1))
     cond = ConditionTemplate(name="name", bounds=IntegerBounds(0, 1))
@@ -162,9 +162,9 @@ def test_dependences():
                           ]
                           )
 
-    assert template not in meas.all_dependences()
-    assert spec in meas.all_dependences()
-    assert mat in meas.all_dependences()
-    assert prop in meas.all_dependences()
-    assert cond in meas.all_dependences()
-    assert param in meas.all_dependences()
+    assert template not in meas.all_dependencies()
+    assert spec in meas.all_dependencies()
+    assert mat in meas.all_dependencies()
+    assert prop in meas.all_dependencies()
+    assert cond in meas.all_dependencies()
+    assert param in meas.all_dependencies()

--- a/gemd/entity/object/tests/test_measurement_run.py
+++ b/gemd/entity/object/tests/test_measurement_run.py
@@ -3,14 +3,16 @@ import pytest
 from uuid import uuid4
 
 from gemd.json import dumps, loads
+from gemd.entity.bounds import IntegerBounds
 from gemd.entity.object import MeasurementRun, MaterialRun
 from gemd.entity.object.measurement_spec import MeasurementSpec
 from gemd.entity.attribute.condition import Condition
 from gemd.entity.attribute.parameter import Parameter
 from gemd.entity.attribute.property import Property
 from gemd.entity.source.performed_source import PerformedSource
-from gemd.entity.template.measurement_template import MeasurementTemplate
-from gemd.entity.value.nominal_real import NominalReal
+from gemd.entity.template import MeasurementTemplate, PropertyTemplate, ParameterTemplate, \
+    ConditionTemplate
+from gemd.entity.value import NominalReal, NominalInteger
 from gemd.entity.file_link import FileLink
 from gemd.entity.link_by_uid import LinkByUID
 from gemd.util.impl import substitute_links
@@ -134,3 +136,35 @@ def test_template_access():
 
     meas.spec = LinkByUID.from_entity(spec)
     assert meas.template is None
+
+
+def test_dependences():
+    """Test that dependency lists make sense."""
+    prop = PropertyTemplate(name="name", bounds=IntegerBounds(0, 1))
+    cond = ConditionTemplate(name="name", bounds=IntegerBounds(0, 1))
+    param = ParameterTemplate(name="name", bounds=IntegerBounds(0, 1))
+
+    template = MeasurementTemplate("measurement template",
+                                   parameters=[param],
+                                   conditions=[cond],
+                                   properties=[prop])
+    spec = MeasurementSpec("A spec", template=template)
+    mat = MaterialRun(name="mr")
+    meas = MeasurementRun("A run", spec=spec, material=mat,
+                          properties=[
+                              Property(prop.name, template=prop, value=NominalInteger(1))
+                          ],
+                          conditions=[
+                              Condition(cond.name, template=cond, value=NominalInteger(1))
+                          ],
+                          parameters=[
+                              Parameter(param.name, template=param, value=NominalInteger(1))
+                          ]
+                          )
+
+    assert template not in meas.all_dependences()
+    assert spec in meas.all_dependences()
+    assert mat in meas.all_dependences()
+    assert prop in meas.all_dependences()
+    assert cond in meas.all_dependences()
+    assert param in meas.all_dependences()

--- a/gemd/entity/setters.py
+++ b/gemd/entity/setters.py
@@ -1,8 +1,10 @@
 """Methods for setting and validating."""
 from gemd.entity.valid_list import ValidList
 
+from typing import Iterable
 
-def validate_list(obj, typ, *, trigger=None):
+
+def validate_list(obj, typ, *, trigger=None) -> ValidList:
     """
     Attempts to return obj as a list, each element of which has type typ.
 
@@ -24,13 +26,13 @@ def validate_list(obj, typ, *, trigger=None):
     """
     if obj is None:
         return ValidList([], typ, trigger)
-    elif isinstance(obj, (list, tuple)):
+    elif isinstance(obj, Iterable):
         return ValidList(obj, typ, trigger)
     else:
         return ValidList([obj], typ, trigger)
 
 
-def validate_str(obj):
+def validate_str(obj) -> str:
     """
     Check that obj is a string and then convert it to unicode.
 
@@ -52,9 +54,4 @@ def validate_str(obj):
     """
     if not isinstance(obj, str):
         raise TypeError("Expected a string but got {} instead".format(type(obj)))
-
-    # If python 2 and the string isn't already unicode, turn it into unicode"""
-    try:
-        return obj.decode("utf-8")
-    except AttributeError:
-        return obj
+    return obj

--- a/gemd/entity/template/attribute_template.py
+++ b/gemd/entity/template/attribute_template.py
@@ -50,7 +50,7 @@ class AttributeTemplate(BaseEntity):
             raise TypeError("Bounds must be an instance of BaseBounds: {}".format(bounds))
         self._bounds = bounds
 
-    def all_dependences(self):
+    def all_dependencies(self):
         """Return a set of all immediate dependencies (no recursion)."""
         # Attribute Templates never depend on other objects.
         return set()

--- a/gemd/entity/template/attribute_template.py
+++ b/gemd/entity/template/attribute_template.py
@@ -49,3 +49,8 @@ class AttributeTemplate(BaseEntity):
         if not isinstance(bounds, BaseBounds):
             raise TypeError("Bounds must be an instance of BaseBounds: {}".format(bounds))
         self._bounds = bounds
+
+    def all_dependences(self):
+        """Return a set of all immediate dependencies (no recursion)."""
+        # Attribute Templates never depend on other objects.
+        return set()

--- a/gemd/entity/template/base_template.py
+++ b/gemd/entity/template/base_template.py
@@ -4,7 +4,7 @@ from gemd.entity.bounds.base_bounds import BaseBounds
 from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.template.attribute_template import AttributeTemplate
 
-from typing import Union, Iterable, Set, Mapping
+from typing import Union, Iterable, Mapping
 
 
 class BaseTemplate(BaseEntity):
@@ -76,16 +76,3 @@ class BaseTemplate(BaseEntity):
                         raise ValueError("Range and template are inconsistent")
                 return [first, second]
         raise TypeError("Expected a template or (template, bounds) tuple")  # pragma: no cover
-
-    def all_dependencies(self) -> Set[AttributeTemplate]:
-        """Return a set of all immediate dependencies (no recursion)."""
-        from gemd.entity.template.has_condition_templates import HasConditionTemplates
-        from gemd.entity.template.has_parameter_templates import HasParameterTemplates
-        from gemd.entity.template.has_property_templates import HasPropertyTemplates
-
-        result = set()
-
-        for typ in (HasConditionTemplates, HasParameterTemplates, HasPropertyTemplates):
-            if isinstance(self, typ):
-                result |= typ.all_dependencies(self)
-        return result

--- a/gemd/entity/template/base_template.py
+++ b/gemd/entity/template/base_template.py
@@ -67,22 +67,15 @@ class BaseTemplate(BaseEntity):
                 return [first, second]
         raise TypeError("Expected a template or (template, bounds) tuple")  # pragma: no cover
 
-    def all_dependences(self):
+    def all_dependencies(self):
         """Return a set of all immediate dependencies (no recursion)."""
-        from gemd.entity.template.has_parameter_templates import HasParameterTemplates
         from gemd.entity.template.has_condition_templates import HasConditionTemplates
+        from gemd.entity.template.has_parameter_templates import HasParameterTemplates
         from gemd.entity.template.has_property_templates import HasPropertyTemplates
 
         result = set()
 
-        if isinstance(self, HasPropertyTemplates):
-            for attr in self.properties:
-                result.add(attr[0])
-        if isinstance(self, HasConditionTemplates):
-            for attr in self.conditions:
-                result.add(attr[0])
-        if isinstance(self, HasParameterTemplates):
-            for attr in self.parameters:
-                result.add(attr[0])
-
+        for typ in (HasConditionTemplates, HasParameterTemplates, HasPropertyTemplates):
+            if isinstance(self, typ):
+                result |= typ.all_dependencies(self)
         return result

--- a/gemd/entity/template/base_template.py
+++ b/gemd/entity/template/base_template.py
@@ -4,6 +4,8 @@ from gemd.entity.bounds.base_bounds import BaseBounds
 from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.template.attribute_template import AttributeTemplate
 
+from typing import Union, Iterable, Set, Mapping
+
 
 class BaseTemplate(BaseEntity):
     """
@@ -26,13 +28,21 @@ class BaseTemplate(BaseEntity):
 
     """
 
-    def __init__(self, name, *, description=None, uids=None, tags=None):
+    def __init__(self,
+                 name: str,
+                 *,
+                 description: str = None,
+                 uids: Mapping[str, str] = None,
+                 tags: Iterable[str] = None):
         BaseEntity.__init__(self, uids, tags)
         self.name = name
         self.description = description
 
     @staticmethod
-    def _homogenize_ranges(template_or_tuple):
+    def _homogenize_ranges(template_or_tuple: Union[AttributeTemplate,
+                                                    LinkByUID,
+                                                    Iterable[Union[AttributeTemplate,
+                                                                   BaseBounds]]]):
         """
         Take either a template or pair and turn it into a (template, bounds) pair.
 
@@ -67,7 +77,7 @@ class BaseTemplate(BaseEntity):
                 return [first, second]
         raise TypeError("Expected a template or (template, bounds) tuple")  # pragma: no cover
 
-    def all_dependencies(self):
+    def all_dependencies(self) -> Set[AttributeTemplate]:
         """Return a set of all immediate dependencies (no recursion)."""
         from gemd.entity.template.has_condition_templates import HasConditionTemplates
         from gemd.entity.template.has_parameter_templates import HasParameterTemplates

--- a/gemd/entity/template/base_template.py
+++ b/gemd/entity/template/base_template.py
@@ -66,3 +66,23 @@ class BaseTemplate(BaseEntity):
                         raise ValueError("Range and template are inconsistent")
                 return [first, second]
         raise TypeError("Expected a template or (template, bounds) tuple")  # pragma: no cover
+
+    def all_dependences(self):
+        """Return a set of all immediate dependencies (no recursion)."""
+        from gemd.entity.template.has_parameter_templates import HasParameterTemplates
+        from gemd.entity.template.has_condition_templates import HasConditionTemplates
+        from gemd.entity.template.has_property_templates import HasPropertyTemplates
+
+        result = set()
+
+        if isinstance(self, HasPropertyTemplates):
+            for attr in self.properties:
+                result.add(attr[0])
+        if isinstance(self, HasConditionTemplates):
+            for attr in self.conditions:
+                result.add(attr[0])
+        if isinstance(self, HasParameterTemplates):
+            for attr in self.parameters:
+                result.add(attr[0])
+
+        return result

--- a/gemd/entity/template/has_condition_templates.py
+++ b/gemd/entity/template/has_condition_templates.py
@@ -1,4 +1,5 @@
 """For entities that have a condition template."""
+from gemd.entity.has_dependencies import HasDependencies
 from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.setters import validate_list
 from gemd.entity.template.base_template import BaseTemplate
@@ -8,7 +9,7 @@ from gemd.entity.bounds.base_bounds import BaseBounds
 from typing import Optional, Union, Iterable, List, Tuple, Set
 
 
-class HasConditionTemplates(object):
+class HasConditionTemplates(HasDependencies):
     """
     Mixin-trait for entities that include condition templates.
 
@@ -66,6 +67,6 @@ class HasConditionTemplates(object):
                                          trigger=BaseTemplate._homogenize_ranges
                                          )
 
-    def all_dependencies(self) -> Set[Union[ConditionTemplate, LinkByUID]]:
+    def _local_dependencies(self) -> Set[Union["BaseEntity", "LinkByUID"]]:
         """Return a set of all immediate dependencies (no recursion)."""
         return {attr[0] for attr in self.conditions}

--- a/gemd/entity/template/has_condition_templates.py
+++ b/gemd/entity/template/has_condition_templates.py
@@ -4,7 +4,8 @@ from gemd.entity.setters import validate_list
 from gemd.entity.template.base_template import BaseTemplate
 from gemd.entity.template.condition_template import ConditionTemplate
 from gemd.entity.bounds.base_bounds import BaseBounds
-from typing import Iterable
+
+from typing import Optional, Union, Iterable, List, Tuple, Set
 
 
 class HasConditionTemplates(object):
@@ -19,12 +20,14 @@ class HasConditionTemplates(object):
 
     """
 
-    def __init__(self, conditions):
+    def __init__(self, conditions: Iterable[Union[Union[ConditionTemplate, LinkByUID],
+                                                  Tuple[Union[ConditionTemplate, LinkByUID],
+                                                        Optional[BaseBounds]]]]):
         self._conditions = None
         self.conditions = conditions
 
     @property
-    def conditions(self):
+    def conditions(self) -> List[Union[ConditionTemplate, LinkByUID]]:
         """
         Get the list of condition template/bounds tuples.
 
@@ -37,7 +40,9 @@ class HasConditionTemplates(object):
         return self._conditions
 
     @conditions.setter
-    def conditions(self, conditions):
+    def conditions(self, conditions: Iterable[Union[Union[ConditionTemplate, LinkByUID],
+                                                    Tuple[Union[ConditionTemplate, LinkByUID],
+                                                          Optional[BaseBounds]]]]):
         """
         Set the list of condition templates.
 
@@ -61,6 +66,6 @@ class HasConditionTemplates(object):
                                          trigger=BaseTemplate._homogenize_ranges
                                          )
 
-    def all_dependencies(self):
+    def all_dependencies(self) -> Set[Union[ConditionTemplate, LinkByUID]]:
         """Return a set of all immediate dependencies (no recursion)."""
         return {attr[0] for attr in self.conditions}

--- a/gemd/entity/template/has_condition_templates.py
+++ b/gemd/entity/template/has_condition_templates.py
@@ -60,3 +60,7 @@ class HasConditionTemplates(object):
                                          (ConditionTemplate, LinkByUID, list, tuple),
                                          trigger=BaseTemplate._homogenize_ranges
                                          )
+
+    def all_dependencies(self):
+        """Return a set of all immediate dependencies (no recursion)."""
+        return {attr[0] for attr in self.conditions}

--- a/gemd/entity/template/has_parameter_templates.py
+++ b/gemd/entity/template/has_parameter_templates.py
@@ -1,4 +1,5 @@
 """For entities that have a parameter template."""
+from gemd.entity.has_dependencies import HasDependencies
 from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.setters import validate_list
 from gemd.entity.template.base_template import BaseTemplate
@@ -8,7 +9,7 @@ from gemd.entity.bounds.base_bounds import BaseBounds
 from typing import Optional, Union, Iterable, List, Tuple, Set
 
 
-class HasParameterTemplates(object):
+class HasParameterTemplates(HasDependencies):
     """
     Mixin-trait for entities that include parameter templates.
 
@@ -66,6 +67,6 @@ class HasParameterTemplates(object):
                                          trigger=BaseTemplate._homogenize_ranges
                                          )
 
-    def all_dependencies(self) -> Set[Union[ParameterTemplate, LinkByUID]]:
+    def _local_dependencies(self) -> Set[Union["BaseEntity", "LinkByUID"]]:
         """Return a set of all immediate dependencies (no recursion)."""
         return {attr[0] for attr in self.parameters}

--- a/gemd/entity/template/has_parameter_templates.py
+++ b/gemd/entity/template/has_parameter_templates.py
@@ -4,7 +4,8 @@ from gemd.entity.setters import validate_list
 from gemd.entity.template.base_template import BaseTemplate
 from gemd.entity.template.parameter_template import ParameterTemplate
 from gemd.entity.bounds.base_bounds import BaseBounds
-from typing import Iterable
+
+from typing import Optional, Union, Iterable, List, Tuple, Set
 
 
 class HasParameterTemplates(object):
@@ -19,12 +20,14 @@ class HasParameterTemplates(object):
 
     """
 
-    def __init__(self, parameters):
+    def __init__(self, parameters: Iterable[Union[Union[ParameterTemplate, LinkByUID],
+                                                  Tuple[Union[ParameterTemplate, LinkByUID],
+                                                        Optional[BaseBounds]]]]):
         self._parameters = None
         self.parameters = parameters
 
     @property
-    def parameters(self):
+    def parameters(self) -> List[Union[ParameterTemplate, LinkByUID]]:
         """
         Get the list of parameter template/bounds tuples.
 
@@ -37,7 +40,9 @@ class HasParameterTemplates(object):
         return self._parameters
 
     @parameters.setter
-    def parameters(self, parameters):
+    def parameters(self, parameters: Iterable[Union[Union[ParameterTemplate, LinkByUID],
+                                                    Tuple[Union[ParameterTemplate, LinkByUID],
+                                                          Optional[BaseBounds]]]]):
         """
         Set the list of parameter templates.
 
@@ -61,6 +66,6 @@ class HasParameterTemplates(object):
                                          trigger=BaseTemplate._homogenize_ranges
                                          )
 
-    def all_dependencies(self):
+    def all_dependencies(self) -> Set[Union[ParameterTemplate, LinkByUID]]:
         """Return a set of all immediate dependencies (no recursion)."""
         return {attr[0] for attr in self.parameters}

--- a/gemd/entity/template/has_parameter_templates.py
+++ b/gemd/entity/template/has_parameter_templates.py
@@ -60,3 +60,7 @@ class HasParameterTemplates(object):
                                          (ParameterTemplate, LinkByUID, list, tuple),
                                          trigger=BaseTemplate._homogenize_ranges
                                          )
+
+    def all_dependencies(self):
+        """Return a set of all immediate dependencies (no recursion)."""
+        return {attr[0] for attr in self.parameters}

--- a/gemd/entity/template/has_property_templates.py
+++ b/gemd/entity/template/has_property_templates.py
@@ -4,7 +4,8 @@ from gemd.entity.setters import validate_list
 from gemd.entity.template.base_template import BaseTemplate
 from gemd.entity.template.property_template import PropertyTemplate
 from gemd.entity.bounds.base_bounds import BaseBounds
-from typing import Iterable
+
+from typing import Optional, Union, Iterable, List, Set, Tuple
 
 
 class HasPropertyTemplates(object):
@@ -19,12 +20,15 @@ class HasPropertyTemplates(object):
 
     """
 
-    def __init__(self, properties):
+    def __init__(self, properties: Iterable[Union[Union[PropertyTemplate, LinkByUID],
+                                                  Tuple[Union[PropertyTemplate, LinkByUID],
+                                                        Optional[BaseBounds]]]]):
         self._properties = None
         self.properties = properties
 
     @property
-    def properties(self):
+    def properties(self) -> List[Tuple[Union[PropertyTemplate, LinkByUID],
+                                       Optional[BaseBounds]]]:
         """
         Get the list of property template/bounds tuples.
 
@@ -37,7 +41,9 @@ class HasPropertyTemplates(object):
         return self._properties
 
     @properties.setter
-    def properties(self, properties):
+    def properties(self, properties: Iterable[Union[Union[PropertyTemplate, LinkByUID],
+                                                    Tuple[Union[PropertyTemplate, LinkByUID],
+                                                          Optional[BaseBounds]]]]):
         """
         Set the list of parameter templates.
 
@@ -46,11 +52,6 @@ class HasPropertyTemplates(object):
         properties: List[(PropertyTemplate, bounds)]
             A list of tuples containing this entity's property templates as well
             as any restrictions on those templates' bounds.
-
-        Returns
-        -------
-        List[(PropertyTemplate, bounds)]
-            List of this entity's property template/bounds pairs
 
         """
         if isinstance(properties, Iterable):
@@ -61,6 +62,6 @@ class HasPropertyTemplates(object):
                                          trigger=BaseTemplate._homogenize_ranges
                                          )
 
-    def all_dependencies(self):
+    def all_dependencies(self) -> Set[Union[PropertyTemplate, LinkByUID]]:
         """Return a set of all immediate dependencies (no recursion)."""
         return {attr[0] for attr in self.properties}

--- a/gemd/entity/template/has_property_templates.py
+++ b/gemd/entity/template/has_property_templates.py
@@ -60,3 +60,7 @@ class HasPropertyTemplates(object):
                                          (PropertyTemplate, LinkByUID, list, tuple),
                                          trigger=BaseTemplate._homogenize_ranges
                                          )
+
+    def all_dependencies(self):
+        """Return a set of all immediate dependencies (no recursion)."""
+        return {attr[0] for attr in self.properties}

--- a/gemd/entity/template/has_property_templates.py
+++ b/gemd/entity/template/has_property_templates.py
@@ -1,4 +1,5 @@
 """For entities that have a property template."""
+from gemd.entity.has_dependencies import HasDependencies
 from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.setters import validate_list
 from gemd.entity.template.base_template import BaseTemplate
@@ -8,7 +9,7 @@ from gemd.entity.bounds.base_bounds import BaseBounds
 from typing import Optional, Union, Iterable, List, Set, Tuple
 
 
-class HasPropertyTemplates(object):
+class HasPropertyTemplates(HasDependencies):
     """
     Mixin-trait for entities that include property templates.
 
@@ -62,6 +63,6 @@ class HasPropertyTemplates(object):
                                          trigger=BaseTemplate._homogenize_ranges
                                          )
 
-    def all_dependencies(self) -> Set[Union[PropertyTemplate, LinkByUID]]:
+    def _local_dependencies(self) -> Set[Union["BaseEntity", "LinkByUID"]]:
         """Return a set of all immediate dependencies (no recursion)."""
         return {attr[0] for attr in self.properties}

--- a/gemd/entity/template/tests/test_base_attribute_template.py
+++ b/gemd/entity/template/tests/test_base_attribute_template.py
@@ -43,7 +43,7 @@ def test_json():
     assert copy == template
 
 
-def test_dependences():
+def test_dependencies():
     """Test that dependency lists make sense."""
     targets = [
         PropertyTemplate(name="name", bounds=RealBounds(0, 1, '')),
@@ -51,4 +51,4 @@ def test_dependences():
         ParameterTemplate(name="name", bounds=RealBounds(0, 1, '')),
     ]
     for target in targets:
-        assert len(target.all_dependences()) == 0, f"{type(target)} had dependencies"
+        assert len(target.all_dependencies()) == 0, f"{type(target)} had dependencies"

--- a/gemd/entity/template/tests/test_base_attribute_template.py
+++ b/gemd/entity/template/tests/test_base_attribute_template.py
@@ -6,6 +6,8 @@ from gemd.entity.bounds.real_bounds import RealBounds
 from gemd.entity.value.uniform_real import UniformReal
 from gemd.entity.template.attribute_template import AttributeTemplate
 from gemd.entity.template.property_template import PropertyTemplate
+from gemd.entity.template.condition_template import ConditionTemplate
+from gemd.entity.template.parameter_template import ParameterTemplate
 from gemd.json import dumps, loads
 
 
@@ -39,3 +41,14 @@ def test_json():
     template = PropertyTemplate(name="foo", bounds=RealBounds(0, 1, ""))
     copy = loads(dumps(template))
     assert copy == template
+
+
+def test_dependences():
+    """Test that dependency lists make sense."""
+    targets = [
+        PropertyTemplate(name="name", bounds=RealBounds(0, 1, '')),
+        ConditionTemplate(name="name", bounds=RealBounds(0, 1, '')),
+        ParameterTemplate(name="name", bounds=RealBounds(0, 1, '')),
+    ]
+    for target in targets:
+        assert len(target.all_dependences()) == 0, f"{type(target)} had dependencies"

--- a/gemd/entity/template/tests/test_measurement_template.py
+++ b/gemd/entity/template/tests/test_measurement_template.py
@@ -72,7 +72,7 @@ def test_mixins():
     assert len(second.parameters) == 1
 
 
-def test_dependences():
+def test_dependencies():
     """Test that dependency lists make sense."""
     prop = PropertyTemplate(name="name", bounds=IntegerBounds(0, 1))
     cond = ConditionTemplate(name="name", bounds=IntegerBounds(0, 1))
@@ -82,6 +82,6 @@ def test_dependences():
                                        conditions=[cond],
                                        properties=[prop],
                                        parameters=[param])
-    assert prop in msr_template.all_dependences()
-    assert cond in msr_template.all_dependences()
-    assert param in msr_template.all_dependences()
+    assert prop in msr_template.all_dependencies()
+    assert cond in msr_template.all_dependencies()
+    assert param in msr_template.all_dependencies()

--- a/gemd/entity/template/tests/test_measurement_template.py
+++ b/gemd/entity/template/tests/test_measurement_template.py
@@ -70,3 +70,18 @@ def test_mixins():
     assert len(second.properties) == 1
     assert len(second.conditions) == 1
     assert len(second.parameters) == 1
+
+
+def test_dependences():
+    """Test that dependency lists make sense."""
+    prop = PropertyTemplate(name="name", bounds=IntegerBounds(0, 1))
+    cond = ConditionTemplate(name="name", bounds=IntegerBounds(0, 1))
+    param = ParameterTemplate(name="name", bounds=IntegerBounds(0, 1))
+
+    msr_template = MeasurementTemplate("a process template",
+                                       conditions=[cond],
+                                       properties=[prop],
+                                       parameters=[param])
+    assert prop in msr_template.all_dependences()
+    assert cond in msr_template.all_dependences()
+    assert param in msr_template.all_dependences()

--- a/gemd/entity/template/tests/test_process_template.py
+++ b/gemd/entity/template/tests/test_process_template.py
@@ -76,9 +76,9 @@ def test_passthrough_bounds():
     assert len(from_dict.conditions) == 1
 
 
-def test_dependences():
+def test_dependencies():
     """Test that dependency lists make sense."""
     attribute_bounds = RealBounds(0, 100, '')
     cond_template = ConditionTemplate("a condition", bounds=attribute_bounds)
     proc_template = ProcessTemplate("a process template", conditions=[cond_template])
-    assert cond_template in proc_template.all_dependences()
+    assert cond_template in proc_template.all_dependencies()

--- a/gemd/entity/template/tests/test_process_template.py
+++ b/gemd/entity/template/tests/test_process_template.py
@@ -74,3 +74,11 @@ def test_passthrough_bounds():
         ],
     })
     assert len(from_dict.conditions) == 1
+
+
+def test_dependences():
+    """Test that dependency lists make sense."""
+    attribute_bounds = RealBounds(0, 100, '')
+    cond_template = ConditionTemplate("a condition", bounds=attribute_bounds)
+    proc_template = ProcessTemplate("a process template", conditions=[cond_template])
+    assert cond_template in proc_template.all_dependences()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.5.0',
+      version='1.6.0',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Citrine Informatics',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.3.0',
+      version='1.4.0',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Citrine Informatics',


### PR DESCRIPTION
This is an initial effort to migrate [_all_dependencies](https://github.com/CitrineInformatics/citrine-python/blob/d164744c99b17f935a09935c2e57d2f056675477/src/citrine/_utils/batcher.py#L120) into gemd-python.  At present, recursive_foreach and recursive_flatmap can crawl a structure to recover all objects but cannot do so in a way that reveals layers that are helpful in batching. 

The current structure of the method calls don't feel quite right, and at least feel like they motivate creation of a has_spec mixin.