### PR TITLE
Performance improvements

### DIFF
--- a/gemd/entity/base_entity.py
+++ b/gemd/entity/base_entity.py
@@ -1,5 +1,6 @@
 """Base class for all entities."""
 from typing import Optional
+from collections.abc import Collection
 
 from gemd.entity.dict_serializable import DictSerializable
 from gemd.entity.case_insensitive_dict import CaseInsensitiveDict
@@ -105,14 +106,93 @@ class BaseEntity(DictSerializable):
 
         return LinkByUID(scope=scope, id=uid)
 
+    @staticmethod
+    def _cached_equals(this: 'BaseEntity', that: 'BaseEntity', cache: dict) -> Optional[bool]:
+        """Compute and stash whether two Base Entities are equal in a recursive sense."""
+        cache_key = frozenset((id(this), id(that)))
+        if cache_key in cache:
+            return cache[cache_key]
+        cache[cache_key] = None  # Mark as in progress
+
+        this_dict = this._dict_for_compare()
+        that_dict = that._dict_for_compare()
+        if this_dict.keys() != that_dict.keys():
+            cache[cache_key] = False  # Mark as failed
+            return False
+
+        # Check UIDs for an easy potential win
+        this_uids = this_dict.pop("uids")
+        that_uids = that_dict.pop("uids")
+        if this_uids != that_uids:
+            cache[cache_key] = False  # Mark as failed
+            return False
+
+        # Crawl rest of values to verify they align
+        for key in this_dict:
+            this_value = this_dict[key]
+            that_value = that_dict[key]
+            if isinstance(this_value, BaseEntity) and isinstance(that_value, BaseEntity):
+                if BaseEntity._cached_equals(this_value, that_value, cache) is False:
+                    cache[cache_key] = False  # Mark as failed
+                    return False
+            elif isinstance(this_value, Collection) and isinstance(that_value, Collection) \
+                    and not isinstance(this_value, str) and not isinstance(that_value, str):
+                # Necessary to maintain context for recursive parts of the structure
+                this_list = list(this_value)
+                that_list = list(that_value)
+                if len(this_list) != len(that_list):
+                    # If an object was flattened, certain lists may be empty
+                    if len(this_list) == 0:
+                        if len(this_uids) > 0:  # But if it was flattened, uids will save us
+                            continue
+                    if len(that_list) == 0:
+                        if len(that_uids) > 0:  # But if it was flattened, uids will save us
+                            continue
+                    cache[cache_key] = False  # Mark as failed
+                    return False
+
+                # Finally crawl and compare
+                for x in this_list:
+                    found = False
+                    i_found = None
+                    if isinstance(x, BaseEntity):
+                        for i_found, y in enumerate(that_list):
+                            # Unless something really broke, y is a BaseEntity
+                            result = BaseEntity._cached_equals(x, y, cache)
+                            if result is True:
+                                found = True
+                                break
+                            elif result is None:
+                                # Don't know yet; pass as False will appear elsewhere
+                                found = None
+                    else:
+                        found = x in that_list
+                    if found is True:
+                        if i_found is not None:
+                            del that_list[i_found]
+                    elif found is False:
+                        cache[cache_key] = False  # Mark as failed
+                        return False
+
+            elif this_value != that_value:  # __eq__ should be cheap
+                cache[cache_key] = False  # Mark as failed
+                return False
+
+        cache[cache_key] = True  # All tests passed
+        return True
+
     # Note that this could violate transitivity -- Link(scope1) == obj == Link(scope2)
     def __eq__(self, other):
         from gemd.entity.link_by_uid import LinkByUID
         if isinstance(other, LinkByUID):
             return self.uids.get(other.scope) == other.id
+        elif isinstance(other, tuple):
+            return len(other) == 2 and other[0] in self.uids and self.uids[other[0]] == other[1]
+        elif isinstance(other, BaseEntity):
+            # We have to be a little clever for efficiency and to avoid infinite recursion
+            return BaseEntity._cached_equals(self, other, dict())
         else:
-            result = super().__eq__(other)
-            return result
+            return super().__eq__(other)
 
     # Note the hash function checks if objects are identical, as opposed to the equals method,
     # which checks if fields are equal.  This is because BaseEntities are fundamentally

--- a/gemd/entity/dict_serializable.py
+++ b/gemd/entity/dict_serializable.py
@@ -3,6 +3,7 @@ from logging import getLogger
 
 import json
 import inspect
+import functools
 
 # There are some weird (probably resolvable) errors during object cloning if this is an
 # instance variable of DictSerializable.
@@ -31,8 +32,7 @@ class DictSerializable(ABC):
             The deserialized object.
 
         """
-        expected_arg_names = inspect.getfullargspec(cls.__init__).args
-        expected_arg_names += inspect.getfullargspec(cls.__init__).kwonlyargs
+        expected_arg_names = cls._init_sig()
         kwargs = {}
         for name, arg in d.items():
             if name in expected_arg_names:
@@ -44,6 +44,14 @@ class DictSerializable(ABC):
         # DictSerializable's constructor is not intended for use,
         # but all of its children will use from_dict like this.
         return cls(**kwargs)
+
+    @classmethod
+    @functools.lru_cache(maxsize=None)
+    def _init_sig(cls):
+        """Internal method for generating the argument names for the class init method."""
+        expected_arg_names = inspect.getfullargspec(cls.__init__).args
+        expected_arg_names += inspect.getfullargspec(cls.__init__).kwonlyargs
+        return expected_arg_names
 
     def as_dict(self):
         """

--- a/gemd/entity/dict_serializable.py
+++ b/gemd/entity/dict_serializable.py
@@ -135,10 +135,14 @@ class DictSerializable(ABC):
             name = getattr(entity, 'name', '<unknown name>')
             return "<{} '{}'>".format(type(entity).__name__, name)
 
+    def _dict_for_compare(self):
+        """Which fields & values are relevant to an equality test."""
+        return self.as_dict()
+
     def __eq__(self, other):
         if isinstance(other, DictSerializable):
-            self_dict = self.as_dict()
-            other_dict = other.as_dict()
+            self_dict = self._dict_for_compare()
+            other_dict = other._dict_for_compare()
             return self_dict == other_dict
         else:
             return NotImplemented

--- a/gemd/entity/link_by_uid.py
+++ b/gemd/entity/link_by_uid.py
@@ -77,7 +77,10 @@ class LinkByUID(DictSerializable):
     def __eq__(self, other):
         from gemd.entity.base_entity import BaseEntity
         if isinstance(other, BaseEntity):
-            return other.uids.get(self.scope) == self.id
+            if self.scope in other.uids:
+                return other.uids[self.scope] == self.id
+            else:
+                return False
         elif isinstance(other, tuple):  # Make them interchangeable in a dict
             return len(other) == 2 and (self.scope, self.id) == other
         else:

--- a/gemd/entity/object/material_run.py
+++ b/gemd/entity/object/material_run.py
@@ -44,7 +44,7 @@ class MaterialRun(BaseObject):
 
     typ = "material_run"
 
-    skip = {"_measurements", "_active_comparison"}
+    skip = {"_measurements"}
 
     def __init__(self, name, *, spec=None, process=None, sample_type="unknown",
                  uids=None, tags=None, notes=None, file_links=None):
@@ -57,7 +57,6 @@ class MaterialRun(BaseObject):
         self._measurements = validate_list(None, [MeasurementRun, LinkByUID])
         self._sample_type = None
         self._spec = None
-        self._active_comparison = set()
 
         self.spec = spec
         self.process = process
@@ -123,33 +122,8 @@ class MaterialRun(BaseObject):
         else:
             return None
 
-    def __eq__(self, other):
-        # To avoid infinite recursion, fast return on revisit
-        if other in self._active_comparison:  # Cycle encountered
-            return True  # This will functionally be & with the correct result of ==
-
-        self._active_comparison.add(other)
-        try:
-            result = super().__eq__(other)
-
-            # Equals needs to crawl into measurements
-            if result is True and isinstance(other, MaterialRun):
-                if len(self.measurements) == len(other.measurements):
-                    result = all(msr in other.measurements for msr in self.measurements)
-                elif (len(self.measurements) == 0 and len(self.uids) != 0) \
-                        or (len(other.measurements) == 0 and len(other.uids) != 0):
-                    result = True  # One can be empty if you flattened
-                else:
-                    result = False
-        finally:
-            self._active_comparison.remove(other)
-
-        return result
-
-    # Note the hash function checks if objects are identical, as opposed to the equals method,
-    # which checks if fields are equal.  This is because BaseEntities are fundamentally
-    # mutable objects.  Note that if you define an __eq__ method without defining a __hash__
-    # method, the object will become unhashable.
-    # https://docs.python.org/3/reference/datamodel.html#object.__hash
-    def __hash__(self):
-        return super().__hash__()
+    def _dict_for_compare(self):
+        """Support for recursive equals."""
+        base = super()._dict_for_compare()
+        base['measurements'] = self.measurements
+        return base

--- a/gemd/entity/object/process_spec.py
+++ b/gemd/entity/object/process_spec.py
@@ -52,7 +52,7 @@ class ProcessSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
 
     typ = "process_spec"
 
-    skip = {"_output_material", "_ingredients", "_active_comparison"}
+    skip = {"_output_material", "_ingredients"}
 
     def __init__(self, name, *, template=None,
                  parameters=None, conditions=None,
@@ -71,7 +71,6 @@ class ProcessSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
         # then the field self._output_material will be automatically populated
         self._output_material = None
         self._ingredients = validate_list(None, [IngredientSpec, LinkByUID])
-        self._active_comparison = set()
 
     @property
     def ingredients(self):
@@ -83,33 +82,8 @@ class ProcessSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
         """Get the output material spec."""
         return self._output_material
 
-    def __eq__(self, other):
-        # To avoid infinite recursion, fast return on revisit
-        if other in self._active_comparison:  # Cycle encountered
-            return True  # This will functionally be & with the correct result of ==
-
-        self._active_comparison.add(other)
-        try:
-            result = super().__eq__(other)
-
-            # Equals needs to crawl into ingredients
-            if result is True and isinstance(other, ProcessSpec):
-                if len(self.ingredients) == len(other.ingredients):
-                    result = all(ing in other.ingredients for ing in self.ingredients)
-                elif (len(self.ingredients) == 0 and len(self.uids) != 0) \
-                        or (len(other.ingredients) == 0 and len(other.uids) != 0):
-                    result = True  # One can be empty if you flattened
-                else:
-                    result = False
-        finally:
-            self._active_comparison.remove(other)
-
-        return result
-
-    # Note the hash function checks if objects are identical, as opposed to the equals method,
-    # which checks if fields are equal.  This is because BaseEntities are fundamentally
-    # mutable objects.  Note that if you define an __eq__ method without defining a __hash__
-    # method, the object will become unhashable.
-    # https://docs.python.org/3/reference/datamodel.html#object.__hash
-    def __hash__(self):
-        return super().__hash__()
+    def _dict_for_compare(self):
+        """Support for recursive equals."""
+        base = super()._dict_for_compare()
+        base['ingredients'] = self.ingredients
+        return base

--- a/gemd/entity/tests/test_entity.py
+++ b/gemd/entity/tests/test_entity.py
@@ -59,8 +59,8 @@ def test_equality():
     # And a cycle is not a problem
     one_mat = MaterialSpec("Material", tags=["other tags!"], process=one)
     two_mat = MaterialSpec("Material", tags=["other tags!"], process=two)
-    one_ing.material = one_mat
-    two_ing = IngredientSpec("Ingredient", process=one, material=one_mat)
+    one_ing.material = two_mat
+    IngredientSpec("Ingredient", process=two, material=one_mat)  # two_ing
     assert one == two
     assert two == one
 
@@ -69,4 +69,3 @@ def test_equality():
     two.tags = ["Four", "One", "Three", "Two"]
     assert one == two
     assert two == one
-

--- a/gemd/entity/tests/test_link_by_uid.py
+++ b/gemd/entity/tests/test_link_by_uid.py
@@ -44,3 +44,15 @@ def test_from_entity():
 
     with pytest.raises(ValueError):
         LinkByUID.from_entity(run, name='scope1', scope='scope2')
+
+
+def test_equality():
+    """Test that the __eq__ method performs as expected."""
+    link = LinkByUID(scope="foo", id="bar")
+    assert link == ProcessRun("Good", uids={"foo": "bar"})
+    assert link != ProcessRun("Good", uids={"foo": "rab"})
+    assert link != ProcessRun("Good", uids={"oof": "bar"})
+    assert link != LinkByUID(scope="foo", id="rab")
+    assert link == ("foo", "bar")
+    assert link != ("foo", "bar", "baz")
+    assert link != ("foo", "rab")

--- a/gemd/util/impl.py
+++ b/gemd/util/impl.py
@@ -215,6 +215,8 @@ def _setter_by_name(clazz: type, name: str) -> Callable:
         setter = _emulator(f"_name")
     elif prop is None:  # It's not a property, just an ordinary attribute
         setter = _emulator(name)
+    elif prop.fset is None:  # It's read only, so set directly
+        setter = _emulator(f"_name")  # pragma: no cover  citrine-python needs this
     else:
         setter = prop.fset
 

--- a/gemd/util/tests/test_substitute_links.py
+++ b/gemd/util/tests/test_substitute_links.py
@@ -97,3 +97,16 @@ def test_signature():
         with pytest.raises(ValueError):  # Test deprecated auto-population
             run5 = ProcessRun("Fifth process run", uids={'my': 'run4'}, spec=spec)
             assert isinstance(substitute_links(run5, scope="my", native_uid="my").spec, LinkByUID)
+
+
+def test_inplace_v_not():
+    """Test that client can copy a dictionary in which keys are BaseEntity objects."""
+    spec = ProcessSpec("A process spec", uids={'id': str(uuid4()), 'auto': str(uuid4())})
+    run1 = ProcessRun("A process run", spec=spec, uids={'id': str(uuid4()), 'auto': str(uuid4())})
+    run2 = ProcessRun("Another process run", spec=spec, uids={'id': str(uuid4())})
+    process_dict = {spec: [run1, run2]}
+
+    subbed = substitute_links(process_dict)
+    assert subbed != process_dict  # This is true because the hashes change, even if objects equal
+    substitute_links(process_dict, inplace=True)
+    assert subbed == process_dict

--- a/gemd/util/tests/test_substitute_objects.py
+++ b/gemd/util/tests/test_substitute_objects.py
@@ -106,8 +106,6 @@ def test_complex_substitutions():
                                  )
     unique = [x for i, x in enumerate(all_objs) if i == all_objs.index(x)]
     assert not any(isinstance(x, LinkByUID) for x in unique), "All are objects"
-    for x in unique:
-        print(x.typ, x.name)
     assert len(links) == len(unique), "Objects are missing"
 
 

--- a/gemd/util/tests/test_substitute_objects.py
+++ b/gemd/util/tests/test_substitute_objects.py
@@ -1,9 +1,10 @@
-from gemd.util.impl import substitute_objects, recursive_foreach
-from gemd.entity.object import ProcessRun, MaterialRun, MeasurementSpec
+from gemd.util import substitute_objects, recursive_foreach, flatten, make_index, recursive_flatmap
+from gemd.util.impl import _substitute, _substitute_inplace
+from gemd.entity.object import MaterialSpec, MaterialRun, ProcessSpec, ProcessRun, IngredientRun, \
+    IngredientSpec, MeasurementSpec
+from gemd.entity.template import ProcessTemplate, ParameterTemplate, MeasurementTemplate
 from gemd.entity.value.normal_real import NormalReal
 from gemd.entity.attribute.parameter import Parameter
-from gemd.entity.template.parameter_template import ParameterTemplate
-from gemd.entity.template.measurement_template import MeasurementTemplate
 from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.bounds.real_bounds import RealBounds
 
@@ -53,3 +54,120 @@ def test_recursive_foreach():
 
     for ent in [param_template, meas_template, measurement]:
         assert new_tag in ent.tags
+
+
+def test_substitute_equivalence():
+    """PLA-6423: verify that substitutions match up."""
+    spec = ProcessSpec(name="old spec", uids={'scope': 'spec'})
+    run = ProcessRun(name="old run",
+                     uids={'scope': 'run'},
+                     spec=LinkByUID(id='spec', scope="scope"))
+
+    # make a dictionary from ids to objects, to be used in substitute_objects
+    gem_index = make_index([run, spec])
+    substitute_objects(obj=run, index=gem_index, inplace=True)
+    assert spec == run.spec
+
+
+def test_complex_substitutions():
+    """Make sure accounting works for realistic objects."""
+    root = MaterialRun("root",
+                       process=ProcessRun("root", spec=ProcessSpec("root")),
+                       spec=MaterialSpec("root")
+                       )
+    root.spec.process = root.process.spec
+    input = MaterialRun("input",
+                        process=ProcessRun("input", spec=ProcessSpec("input")),
+                        spec=MaterialSpec("input")
+                        )
+    input.spec.process = input.process.spec
+    IngredientRun(process=root.process,
+                  material=input,
+                  spec=IngredientSpec("ingredient",
+                                      process=root.process.spec,
+                                      material=input.spec
+                                      )
+                  )
+    param = ParameterTemplate("Param", bounds=RealBounds(-1, 1, "m"))
+    root.process.spec.template = ProcessTemplate("Proc",
+                                                 parameters=[param]
+                                                 )
+    root.process.parameters.append(Parameter("Param",
+                                             value=NormalReal(0, 1, 'm'),
+                                             template=param))
+
+    links = flatten(root, scope="test-scope")
+    index = make_index(links)
+    rebuild = substitute_objects(links, index, inplace=True)
+    rebuilt_root = next(x for x in rebuild if x.name == root.name and x.typ == root.typ)
+    all_objs = recursive_flatmap(rebuilt_root,
+                                 func=lambda x: [x],
+                                 unidirectional=False
+                                 )
+    unique = [x for i, x in enumerate(all_objs) if i == all_objs.index(x)]
+    assert not any(isinstance(x, LinkByUID) for x in unique), "All are objects"
+    for x in unique:
+        print(x.typ, x.name)
+    assert len(links) == len(unique), "Objects are missing"
+
+
+def test_sub_inplace_lists():
+    """Verify consistency for nested lists."""
+    lst_one = [1, 2, 3]
+    lol_main = [
+        lst_one,
+        [
+            [1, 2, 3],
+        ],
+        lst_one
+    ]
+    lol_dup = _substitute(lol_main,
+                          applies=lambda x: isinstance(x, int),
+                          sub=lambda x: x + 1)
+    assert lol_dup != lol_main
+
+    lol_mod = _substitute_inplace(lol_main,
+                                  applies=lambda x: isinstance(x, int),
+                                  sub=lambda x: x + 1)
+    assert lol_mod == lol_main
+    assert lol_mod == lol_dup
+
+
+def test_sub_inplace_tuples():
+    """Verify consistency for nested tuples."""
+    lot_main = [  # Base object must mutable to make sense for inplace
+        (1, 2, 3),
+        (
+            (1, 2, 3),
+        ),
+        (1, 2, 3)
+    ]
+    lot_dup = _substitute(lot_main,
+                          applies=lambda x: isinstance(x, int),
+                          sub=lambda x: x + 1)
+    assert lot_dup != lot_main
+
+    lot_mod = _substitute_inplace(lot_main,
+                                  applies=lambda x: isinstance(x, int),
+                                  sub=lambda x: x + 1)
+    assert lot_mod == lot_main
+    assert lot_mod == lot_dup
+
+
+def test_sub_inplace_dicts():
+    """Verify consistency for nested dicts."""
+    dod_main = {
+        1: 1,
+        "sub": {1: 1, 2: 2, 3: 3},
+        3: 3,
+    }
+    dod_dup = _substitute(dod_main,
+                          applies=lambda x: isinstance(x, int),
+                          sub=lambda x: x + 1)
+    assert dod_dup != dod_main
+
+    dod_mod = _substitute_inplace(dod_main,
+                                  applies=lambda x: isinstance(x, int),
+                                  sub=lambda x: x + 1)
+    assert dod_mod == dod_main
+    assert dod_mod == dod_dup

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.3.0',
+      version='1.4.0',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Citrine Informatics',


### PR DESCRIPTION
This PR has two major changes in response to performance hits taken in our end-to-end test, plus some minor improvements:
1. The DictSerializable comparison method was rewritten to be more efficient.  This included a method to override for objects for which fields of interest aren't exactly the key-value pairs in the serialized version.
2. A substitute in place method was written because copying overhead showed up as significant in profiling.
3. Caching was also added to a few introspection methods that also showed up in the profiles.
4. The existing substitute method was discovered to be vulnerable to infinite recursion when the result of the sub() function yielded a True from applies().

These changes yielded a speedup of about 2x.

This also resolves [PLA-6423](https://citrine.atlassian.net/browse/PLA-6423)