### PR TITLE
Cleaned up inheritence on setters

### DIFF
--- a/gemd/entity/object/base_object.py
+++ b/gemd/entity/object/base_object.py
@@ -1,3 +1,5 @@
+import functools
+
 from gemd.entity.base_entity import BaseEntity
 from gemd.entity.file_link import FileLink
 from gemd.entity.setters import validate_list, validate_str
@@ -34,8 +36,20 @@ class BaseObject(BaseEntity):
         self._name = None
         self._file_links = None
 
-        self.name = name
+        if self._attribute_has_setter("name"):
+            self.name = name
         self.file_links = file_links
+
+    @classmethod
+    @functools.lru_cache(maxsize=None)
+    def _attribute_has_setter(cls, name: str) -> bool:
+        """
+        Internal method to identify if an attribute has a setter method.
+
+        Necessary because IngredientRun clobbers the name setter.
+        """
+        prop = getattr(cls, name, None)
+        return prop is None or prop.fset is not None
 
     @property
     def name(self):

--- a/gemd/entity/object/ingredient_run.py
+++ b/gemd/entity/object/ingredient_run.py
@@ -73,14 +73,6 @@ class IngredientRun(BaseObject, HasQuantities):
         else:
             return super().name
 
-    @name.setter
-    def name(self, name):
-        # This messiness is a consequence of name being an inherited attribute
-        if name is not None:
-            raise AttributeError("Name is set implicitly by associating with an "
-                                 "IngredientSpec")
-        self._name = name
-
     @property
     def labels(self):
         """Get labels."""

--- a/gemd/units/impl.py
+++ b/gemd/units/impl.py
@@ -1,9 +1,11 @@
 """Implementation of units."""
 import pint
-import pkg_resources
-from typing import Union
 from pint import UnitRegistry
 from pint.unit import _Unit
+import pkg_resources
+
+import functools
+from typing import Union
 
 
 # use the default unit registry for now
@@ -17,6 +19,7 @@ IncompatibleUnitsError = pint.errors.DimensionalityError
 UndefinedUnitError = pint.errors.UndefinedUnitError
 
 
+@functools.lru_cache(maxsize=None)
 def parse_units(units: Union[str, _Unit, None]) -> Union[str, _Unit, None]:
     """
     Parse a string or _Unit into a standard string representation of the unit.

--- a/gemd/util/tests/test_substitute_objects.py
+++ b/gemd/util/tests/test_substitute_objects.py
@@ -169,3 +169,15 @@ def test_sub_inplace_dicts():
                                   sub=lambda x: x + 1)
     assert dod_mod == dod_main
     assert dod_mod == dod_dup
+
+
+def test_sub_inplace_objects():
+    """Verify consistency for GEMD objects."""
+    run = IngredientRun(spec=IngredientSpec("string"), notes="note")
+    run.spec = None
+
+    _substitute_inplace(run,
+                        applies=lambda x: isinstance(x, str),
+                        sub=lambda x: f"{x}s")
+    assert run.name == "strings"
+    assert run.notes == "notes"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.4.0',
+      version='1.4.1',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Citrine Informatics',


### PR DESCRIPTION
This moves a unit specific check out of the `_substitute_inplace` method and adds a conditional to the `BaseObject` constructor to identify whether to set the name.