### PR TITLE
Simplify import interface

### DIFF
--- a/gemd/__init__.py
+++ b/gemd/__init__.py
@@ -1,1 +1,30 @@
 """Data concepts library."""
+# flake8: noqa
+from .entity import Condition, Parameter, Property, PropertyAndConditions, \
+    CategoricalBounds, CompositionBounds, IntegerBounds, \
+    MolecularStructureBounds, RealBounds, \
+    MaterialRun, MeasurementRun, ProcessRun, IngredientRun, \
+    MaterialSpec, MeasurementSpec, ProcessSpec, IngredientSpec, \
+    PerformedSource, \
+    PropertyTemplate, ConditionTemplate, ParameterTemplate, \
+    MaterialTemplate, MeasurementTemplate, ProcessTemplate, \
+    NominalReal, NormalReal, UniformReal, NominalInteger, \
+    UniformInteger, DiscreteCategorical, NominalCategorical, \
+    EmpiricalFormula, NominalComposition, InChI, Smiles, \
+    LinkByUID, \
+    FileLink
+
+__all__ = ["Condition", "Parameter", "Property", "PropertyAndConditions",
+           "CategoricalBounds", "CompositionBounds", "IntegerBounds",
+           "MolecularStructureBounds", "RealBounds",
+           "MaterialRun", "MeasurementRun", "ProcessRun", "IngredientRun",
+           "MaterialSpec", "MeasurementSpec", "ProcessSpec", "IngredientSpec",
+           "PerformedSource",
+           "PropertyTemplate", "ConditionTemplate", "ParameterTemplate",
+           "MaterialTemplate", "MeasurementTemplate", "ProcessTemplate",
+           "NominalReal", "NormalReal", "UniformReal", "NominalInteger",
+           "UniformInteger", "DiscreteCategorical", "NominalCategorical",
+           "EmpiricalFormula", "NominalComposition", "InChI", "Smiles",
+           "LinkByUID",
+           "FileLink"
+           ]

--- a/gemd/entity/__init__.py
+++ b/gemd/entity/__init__.py
@@ -1,1 +1,29 @@
 # flake8: noqa
+from .attribute import Condition, Parameter, Property, PropertyAndConditions
+from .bounds import CategoricalBounds, CompositionBounds, IntegerBounds, \
+    MolecularStructureBounds, RealBounds
+from .object import MaterialRun, MeasurementRun, ProcessRun, IngredientRun, \
+    MaterialSpec, MeasurementSpec, ProcessSpec, IngredientSpec
+from .source import PerformedSource
+from .template import PropertyTemplate, ConditionTemplate, ParameterTemplate, \
+    MaterialTemplate, MeasurementTemplate, ProcessTemplate
+from .value import NominalReal, NormalReal, UniformReal, NominalInteger, \
+    UniformInteger, DiscreteCategorical, NominalCategorical, \
+    EmpiricalFormula, NominalComposition, InChI, Smiles
+from .link_by_uid import LinkByUID
+from .file_link import FileLink
+
+__all__ = ["Condition", "Parameter", "Property", "PropertyAndConditions",
+           "CategoricalBounds", "CompositionBounds", "IntegerBounds",
+           "MolecularStructureBounds", "RealBounds",
+           "MaterialRun", "MeasurementRun", "ProcessRun", "IngredientRun",
+           "MaterialSpec", "MeasurementSpec", "ProcessSpec", "IngredientSpec",
+           "PerformedSource",
+           "PropertyTemplate", "ConditionTemplate", "ParameterTemplate",
+           "MaterialTemplate", "MeasurementTemplate", "ProcessTemplate",
+           "NominalReal", "NormalReal", "UniformReal", "NominalInteger",
+           "UniformInteger", "DiscreteCategorical", "NominalCategorical",
+           "EmpiricalFormula", "NominalComposition", "InChI", "Smiles",
+           "LinkByUID",
+           "FileLink"
+           ]

--- a/gemd/entity/attribute/__init__.py
+++ b/gemd/entity/attribute/__init__.py
@@ -4,3 +4,5 @@ from .condition import Condition
 from .parameter import Parameter
 from .property import Property
 from .property_and_conditions import PropertyAndConditions
+
+__all__ = ["Property", "Condition", "Parameter", "PropertyAndConditions"]

--- a/gemd/entity/attribute/tests/test_imports.py
+++ b/gemd/entity/attribute/tests/test_imports.py
@@ -1,0 +1,17 @@
+# Need * to make sure we're hitting collisions if they could happen
+from gemd import *  # noqa: F401, F403
+
+
+class ImportTestObj:
+    """A class that has a property."""
+
+    @property
+    def test_property(self):
+        """A property to validate decorator functionality."""
+        Property(name='Trial')  # noqa: F405
+        return True
+
+
+def test_imports():
+    """* used to import property, which shadowed @property."""
+    assert ImportTestObj().test_property

--- a/gemd/entity/bounds/__init__.py
+++ b/gemd/entity/bounds/__init__.py
@@ -5,3 +5,6 @@ from .composition_bounds import CompositionBounds
 from .integer_bounds import IntegerBounds
 from .molecular_structure_bounds import MolecularStructureBounds
 from .real_bounds import RealBounds
+
+__all__ = ["RealBounds", "IntegerBounds", "CategoricalBounds", "CompositionBounds",
+           "MolecularStructureBounds"]

--- a/gemd/entity/object/__init__.py
+++ b/gemd/entity/object/__init__.py
@@ -8,3 +8,6 @@ from .measurement_spec import MeasurementSpec
 from .process_spec import ProcessSpec
 from .ingredient_run import IngredientRun
 from .ingredient_spec import IngredientSpec
+
+__all__ = ["ProcessSpec", "MaterialSpec", "IngredientSpec", "MeasurementSpec",
+           "ProcessRun", "MaterialRun", "IngredientRun", "MeasurementRun"]

--- a/gemd/entity/source/__init__.py
+++ b/gemd/entity/source/__init__.py
@@ -1,0 +1,4 @@
+# flake8: noqa
+from .performed_source import PerformedSource
+
+__all__ = ["PerformedSource"]

--- a/gemd/entity/template/__init__.py
+++ b/gemd/entity/template/__init__.py
@@ -6,3 +6,6 @@ from .parameter_template import ParameterTemplate
 from .material_template import MaterialTemplate
 from .measurement_template import MeasurementTemplate
 from .process_template import ProcessTemplate
+
+__all__ = ["PropertyTemplate", "ConditionTemplate", "ParameterTemplate",
+           "ProcessTemplate", "MaterialTemplate", "MeasurementTemplate"]

--- a/gemd/entity/value/__init__.py
+++ b/gemd/entity/value/__init__.py
@@ -11,3 +11,10 @@ from .empirical_formula import EmpiricalFormula
 from .nominal_composition import NominalComposition
 from .inchi_value import InChI
 from .smiles_value import Smiles
+
+__all__ = ["NominalReal", "NormalReal", "UniformReal",
+           "NominalInteger", "UniformInteger",
+           "NominalCategorical", "DiscreteCategorical",
+           "NominalComposition", "EmpiricalFormula",
+           "InChI", "Smiles"
+           ]

--- a/gemd/units/__init__.py
+++ b/gemd/units/__init__.py
@@ -1,2 +1,6 @@
 # flake8: noqa
-from .impl import *
+from .impl import parse_units, convert_units, change_definitions_file, \
+    UndefinedUnitError, IncompatibleUnitsError
+
+__all__ = [parse_units, convert_units, change_definitions_file,
+           UndefinedUnitError, IncompatibleUnitsError]

--- a/gemd/util/__init__.py
+++ b/gemd/util/__init__.py
@@ -1,3 +1,6 @@
 # flake8: noqa
 from .impl import set_uuids, make_index, substitute_links, substitute_objects, flatten, \
     recursive_foreach, recursive_flatmap, writable_sort_order
+
+__all__ = ["set_uuids", "make_index", "substitute_links", "substitute_objects", "flatten",
+           "recursive_foreach", "recursive_flatmap", "writable_sort_order"]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.4.1',
+      version='1.5.0',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Citrine Informatics',


### PR DESCRIPTION
This PR adds the ability to import `gemd.entity` members from a variety of package levels, including supporting `from gemd import *` to get all entities that a user would normally interact with.

This PR also defines `__all__` lists in the `__init__.py` files to keep the namespace from getting too polluted from `import *`.  This is especially important because the `property.py` file was clobbering the Python `@property` built-in, causing some very confusing bugs.