### PR TITLE
Add local validation framework for GEMD objects

### DIFF
--- a/gemd/entity/attribute/tests/test_base_attribute.py
+++ b/gemd/entity/attribute/tests/test_base_attribute.py
@@ -6,7 +6,7 @@ from gemd.entity.template.process_template import ProcessTemplate
 from gemd.entity.template.property_template import PropertyTemplate
 from gemd.entity.value.nominal_real import NominalReal
 from gemd.entity.bounds.real_bounds import RealBounds
-from gemd.entity.bounds_validation import validation_context, WarningLevel
+from gemd.entity.bounds_validation import validation_level, WarningLevel
 
 
 def test_invalid_assignment(caplog):
@@ -29,24 +29,24 @@ def test_invalid_assignment(caplog):
     good_val = valid_prop.value
     bad_val = NominalReal(-10.0, '')
     assert len(caplog.records) == 0, "Warning caught before logging tests were reached."
-    with validation_context(WarningLevel.IGNORE):
+    with validation_level(WarningLevel.IGNORE):
         valid_prop.value = bad_val
         assert len(caplog.records) == 0, "Validation warned even though level is IGNORE."
         assert valid_prop.value == bad_val, "IGNORE allowed the bad value to be set."
         valid_prop.value = good_val
         assert len(caplog.records) == 0, "Validation warned even though level is IGNORE."
-    with validation_context(WarningLevel.WARNING):
+    with validation_level(WarningLevel.WARNING):
         valid_prop.value = bad_val
         assert len(caplog.records) == 1, "Validation didn't warn on out of bounds value."
         assert valid_prop.value == bad_val, "WARNING allowed the bad value to be set."
         valid_prop.value = good_val
         assert len(caplog.records) == 1, "Validation DID warn on a valid value."
-    with validation_context(WarningLevel.FATAL):
+    with validation_level(WarningLevel.FATAL):
         with pytest.raises(ValueError):
             valid_prop.value = bad_val
         assert valid_prop.value == good_val, "FATAL didn't allow the bad value to be set."
 
-    with validation_context(WarningLevel.FATAL):
+    with validation_level(WarningLevel.FATAL):
         with pytest.raises(ValueError):
             valid_prop.template = PropertyTemplate("template",
                                                    bounds=RealBounds(0, 1, '')

--- a/gemd/entity/bounds_validation.py
+++ b/gemd/entity/bounds_validation.py
@@ -32,7 +32,7 @@ def set_validation_level(level: WarningLevel):
 
 
 @contextmanager
-def validation_context(level: WarningLevel):
+def validation_level(level: WarningLevel):
     """Provide a context for setting a WarningLevel locally."""
     global BOUNDS_VALIDATION
     # Swap values and store

--- a/gemd/entity/object/has_conditions.py
+++ b/gemd/entity/object/has_conditions.py
@@ -1,4 +1,5 @@
 """For entities that have conditions."""
+from gemd.entity.template.has_condition_templates import HasConditionTemplates
 from gemd.entity.attribute.condition import Condition
 from gemd.entity.setters import validate_list
 from gemd.entity.bounds_validation import get_validation_level, WarningLevel
@@ -30,7 +31,8 @@ class HasConditions(object):
             # if Has_Templates hasn't been called yet, it won't have a _template attribute
             template = getattr(self, "template", None)
             level = get_validation_level()
-            accept = level == WarningLevel.IGNORE or template is None \
+            accept = level == WarningLevel.IGNORE \
+                or not isinstance(template, HasConditionTemplates) \
                 or self.template.validate_condition(x)
 
             if not accept:

--- a/gemd/entity/object/has_conditions.py
+++ b/gemd/entity/object/has_conditions.py
@@ -1,16 +1,14 @@
 """For entities that have conditions."""
 from gemd.entity.has_dependencies import HasDependencies
+from gemd.entity.object.has_template_check_generator import HasTemplateCheckGenerator
 from gemd.entity.template.has_condition_templates import HasConditionTemplates
 from gemd.entity.attribute.condition import Condition
 from gemd.entity.setters import validate_list
 
-from abc import abstractmethod
-from typing import Union, Iterable, List, Set, Callable, TypeVar
-
-T = TypeVar('T')
+from typing import Union, Iterable, List, Set
 
 
-class HasConditions(HasDependencies):
+class HasConditions(HasTemplateCheckGenerator, HasDependencies):
     """Mixin-trait for entities that include conditions.
 
     Parameters
@@ -28,10 +26,6 @@ class HasConditions(HasDependencies):
     def conditions(self) -> List[Condition]:
         """Get a list of the conditions."""
         return self._conditions
-
-    @abstractmethod
-    def _generate_template_check(self, validate: Callable[[T], bool]) -> Callable[[T], T]:
-        """Generate a closure for the object and the validation routine."""
 
     @conditions.setter
     def conditions(self, conditions: Iterable[Condition]):

--- a/gemd/entity/object/has_parameters.py
+++ b/gemd/entity/object/has_parameters.py
@@ -1,16 +1,14 @@
 """For entities that have parameters."""
 from gemd.entity.has_dependencies import HasDependencies
+from gemd.entity.object.has_template_check_generator import HasTemplateCheckGenerator
 from gemd.entity.template.has_parameter_templates import HasParameterTemplates
 from gemd.entity.attribute.parameter import Parameter
 from gemd.entity.setters import validate_list
 
-from abc import abstractmethod
-from typing import Union, Iterable, List, Set, Callable, TypeVar
-
-T = TypeVar('T')
+from typing import Union, Iterable, List, Set
 
 
-class HasParameters(HasDependencies):
+class HasParameters(HasTemplateCheckGenerator, HasDependencies):
     """Mixin-trait for entities that include parameters.
 
     Parameters
@@ -28,10 +26,6 @@ class HasParameters(HasDependencies):
     def parameters(self) -> List[Parameter]:
         """Get the list of parameters."""
         return self._parameters
-
-    @abstractmethod
-    def _generate_template_check(self, validate: Callable[[T], bool]) -> Callable[[T], T]:
-        """Generate a closure for the object and the validation routine."""
 
     @parameters.setter
     def parameters(self, parameters: Iterable[Parameter]):

--- a/gemd/entity/object/has_parameters.py
+++ b/gemd/entity/object/has_parameters.py
@@ -1,4 +1,5 @@
 """For entities that have parameters."""
+from gemd.entity.template.has_parameter_templates import HasParameterTemplates
 from gemd.entity.attribute.parameter import Parameter
 from gemd.entity.setters import validate_list
 from gemd.entity.bounds_validation import get_validation_level, WarningLevel
@@ -30,7 +31,8 @@ class HasParameters(object):
             # if Has_Templates hasn't been called yet, it won't have a _template attribute
             template = getattr(self, "template", None)
             level = get_validation_level()
-            accept = level == WarningLevel.IGNORE or template is None \
+            accept = level == WarningLevel.IGNORE \
+                or not isinstance(template, HasParameterTemplates) \
                 or self.template.validate_parameter(x)
 
             if not accept:

--- a/gemd/entity/object/has_properties.py
+++ b/gemd/entity/object/has_properties.py
@@ -3,10 +3,11 @@ from gemd.entity.has_dependencies import HasDependencies
 from gemd.entity.template.has_property_templates import HasPropertyTemplates
 from gemd.entity.attribute.property import Property
 from gemd.entity.setters import validate_list
-from gemd.entity.bounds_validation import get_validation_level, WarningLevel
-from gemd.entity.dict_serializable import logger
 
-from typing import Union, Iterable, List, Set
+from abc import abstractmethod
+from typing import Union, Iterable, List, Set, Callable, TypeVar
+
+T = TypeVar('T')
 
 
 class HasProperties(HasDependencies):
@@ -28,26 +29,15 @@ class HasProperties(HasDependencies):
         """Get a list of the properties."""
         return self._properties
 
+    @abstractmethod
+    def _generate_template_check(self, validate: Callable[[T], bool]) -> Callable[[T], T]:
+        """Generate a closure for the object and the validation routine."""
+
     @properties.setter
     def properties(self, properties: Iterable[Property]):
         """Set the list of properties."""
-        def _template_check(x: Property) -> Property:
-            # if Has_Templates hasn't been called yet, it won't have a _template attribute
-            template = getattr(self, "template", None)
-            level = get_validation_level()
-            accept = level == WarningLevel.IGNORE \
-                or not isinstance(template, HasPropertyTemplates) \
-                or self.template.validate_property(x)
-
-            if not accept:
-                message = f"Value {x.value} is inconsistent with template {template.name}"
-                if level == WarningLevel.WARNING:
-                    logger.warning(message)
-                else:
-                    raise ValueError(message)
-            return x
-
-        self._properties = validate_list(properties, Property, trigger=_template_check)
+        checker = self._generate_template_check(HasPropertyTemplates.validate_property)
+        self._properties = validate_list(properties, Property, trigger=checker)
 
     def _local_dependencies(self) -> Set[Union["BaseEntity", "LinkByUID"]]:
         """Return a set of all immediate dependencies (no recursion)."""

--- a/gemd/entity/object/has_properties.py
+++ b/gemd/entity/object/has_properties.py
@@ -1,16 +1,14 @@
 """For entities that have properties."""
 from gemd.entity.has_dependencies import HasDependencies
+from gemd.entity.object.has_template_check_generator import HasTemplateCheckGenerator
 from gemd.entity.template.has_property_templates import HasPropertyTemplates
 from gemd.entity.attribute.property import Property
 from gemd.entity.setters import validate_list
 
-from abc import abstractmethod
-from typing import Union, Iterable, List, Set, Callable, TypeVar
-
-T = TypeVar('T')
+from typing import Union, Iterable, List, Set
 
 
-class HasProperties(HasDependencies):
+class HasProperties(HasTemplateCheckGenerator, HasDependencies):
     """Mixin-trait for entities that include properties.
 
     Parameters
@@ -28,10 +26,6 @@ class HasProperties(HasDependencies):
     def properties(self) -> List[Property]:
         """Get a list of the properties."""
         return self._properties
-
-    @abstractmethod
-    def _generate_template_check(self, validate: Callable[[T], bool]) -> Callable[[T], T]:
-        """Generate a closure for the object and the validation routine."""
 
     @properties.setter
     def properties(self, properties: Iterable[Property]):

--- a/gemd/entity/object/has_properties.py
+++ b/gemd/entity/object/has_properties.py
@@ -1,4 +1,5 @@
 """For entities that have properties."""
+from gemd.entity.template.has_property_templates import HasPropertyTemplates
 from gemd.entity.attribute.property import Property
 from gemd.entity.setters import validate_list
 from gemd.entity.bounds_validation import get_validation_level, WarningLevel
@@ -30,7 +31,8 @@ class HasProperties(object):
             # if Has_Templates hasn't been called yet, it won't have a _template attribute
             template = getattr(self, "template", None)
             level = get_validation_level()
-            accept = level == WarningLevel.IGNORE or template is None \
+            accept = level == WarningLevel.IGNORE \
+                or not isinstance(template, HasPropertyTemplates) \
                 or self.template.validate_property(x)
 
             if not accept:

--- a/gemd/entity/object/has_spec.py
+++ b/gemd/entity/object/has_spec.py
@@ -6,9 +6,7 @@ from gemd.entity.template.base_template import BaseTemplate
 from gemd.entity.link_by_uid import LinkByUID
 
 from abc import abstractmethod
-from typing import Optional, Union, Set, Type, Callable, TypeVar
-
-T = TypeVar('T')
+from typing import Optional, Union, Set, Type
 
 
 class HasSpec(HasTemplateCheckGenerator, HasDependencies):

--- a/gemd/entity/object/has_spec.py
+++ b/gemd/entity/object/has_spec.py
@@ -1,7 +1,6 @@
 """For entities that have specs."""
 from gemd.entity.has_dependencies import HasDependencies
 from gemd.entity.object.has_template import HasTemplate
-from gemd.entity.object.has_template_check_generator import HasTemplateCheckGenerator
 from gemd.entity.template.base_template import BaseTemplate
 from gemd.entity.link_by_uid import LinkByUID
 
@@ -9,7 +8,7 @@ from abc import abstractmethod
 from typing import Optional, Union, Set, Type
 
 
-class HasSpec(HasTemplateCheckGenerator, HasDependencies):
+class HasSpec(HasDependencies):
     """Mix-in trait for objects that can be assigned specs.
 
     Parameters

--- a/gemd/entity/object/has_spec.py
+++ b/gemd/entity/object/has_spec.py
@@ -5,7 +5,9 @@ from gemd.entity.template.base_template import BaseTemplate
 from gemd.entity.link_by_uid import LinkByUID
 
 from abc import abstractmethod
-from typing import Optional, Union, Set, Type
+from typing import Optional, Union, Set, Type, Callable, TypeVar
+
+T = TypeVar('T')
 
 
 class HasSpec(HasDependencies):
@@ -50,6 +52,12 @@ class HasSpec(HasDependencies):
             return self.spec.template
         else:
             return None
+
+    def _generate_template_check(self,
+                                 validate: Callable[[Union["HasSpec", "HasTemplate"], T], bool]
+                                 ) -> Callable[[T], T]:
+        """Generate a closure for the object and the validation routine (from HasTemplate)."""
+        return HasTemplate._generate_template_check(self, validate)
 
     def _local_dependencies(self) -> Set[Union["BaseEntity", "LinkByUID"]]:
         """Return a set of all immediate dependencies (no recursion)."""

--- a/gemd/entity/object/has_spec.py
+++ b/gemd/entity/object/has_spec.py
@@ -1,6 +1,7 @@
 """For entities that have specs."""
 from gemd.entity.has_dependencies import HasDependencies
 from gemd.entity.object.has_template import HasTemplate
+from gemd.entity.object.has_template_check_generator import HasTemplateCheckGenerator
 from gemd.entity.template.base_template import BaseTemplate
 from gemd.entity.link_by_uid import LinkByUID
 
@@ -10,7 +11,7 @@ from typing import Optional, Union, Set, Type, Callable, TypeVar
 T = TypeVar('T')
 
 
-class HasSpec(HasDependencies):
+class HasSpec(HasTemplateCheckGenerator, HasDependencies):
     """Mix-in trait for objects that can be assigned specs.
 
     Parameters
@@ -52,12 +53,6 @@ class HasSpec(HasDependencies):
             return self.spec.template
         else:
             return None
-
-    def _generate_template_check(self,
-                                 validate: Callable[[Union["HasSpec", "HasTemplate"], T], bool]
-                                 ) -> Callable[[T], T]:
-        """Generate a closure for the object and the validation routine (from HasTemplate)."""
-        return HasTemplate._generate_template_check(self, validate)
 
     def _local_dependencies(self) -> Set[Union["BaseEntity", "LinkByUID"]]:
         """Return a set of all immediate dependencies (no recursion)."""

--- a/gemd/entity/object/has_template.py
+++ b/gemd/entity/object/has_template.py
@@ -2,9 +2,14 @@
 from gemd.entity.has_dependencies import HasDependencies
 from gemd.entity.template.base_template import BaseTemplate
 from gemd.entity.link_by_uid import LinkByUID
+from gemd.entity.bounds_validation import get_validation_level, WarningLevel
+from gemd.entity.dict_serializable import logger
 
 from abc import abstractmethod
-from typing import Optional, Union, Set, Type
+from inspect import getmodule, isclass
+from typing import Optional, Union, Set, Type, Callable, TypeVar
+
+T = TypeVar('T')
 
 
 class HasTemplate(HasDependencies):
@@ -41,6 +46,44 @@ class HasTemplate(HasDependencies):
         else:
             raise TypeError(f"Template must be a {self._template_type()} or LinkByUID, "
                             f"not {type(template)}")
+
+    def _generate_template_check(self,
+                                 validate: Callable[[Union["HasSpec", "HasTemplate"], T], bool]
+                                 ) -> Callable[[T], T]:
+        """Generate a closure for the object and the validation routine."""
+        from gemd.entity.object.has_spec import HasSpec
+
+        if not isinstance(self, (HasSpec, HasTemplate)):
+            raise ValueError(f"{self} does not support object template checks.")
+
+        module = getmodule(validate)
+        cls = None
+        if module is not None:
+            for member in module.__dict__.values():
+                if isclass(member) and member.__module__ == module.__name__:
+                    cls = member
+                    break
+        if cls is None:
+            raise ValueError(f"Could not map class for function {validate}.")
+        attr = next((y for x, y in validate.__annotations__.items() if x != 'return'), None)
+        if attr is None:
+            raise ValueError(f"Could not map attribute for function {validate}.")
+
+        def template_check(x: attr) -> attr:
+            level = get_validation_level()
+            reject = level != WarningLevel.IGNORE \
+                and isinstance(self.template, cls) \
+                and not validate(self.template, x)
+
+            if reject:
+                message = f"Value {x.value} is inconsistent with template {self.template.name}"
+                if level == WarningLevel.WARNING:
+                    logger.warning(message)
+                else:
+                    raise ValueError(message)
+            return x
+
+        return template_check
 
     def _local_dependencies(self) -> Set[Union["BaseEntity", "LinkByUID"]]:
         """Return a set of all immediate dependencies (no recursion)."""

--- a/gemd/entity/object/has_template.py
+++ b/gemd/entity/object/has_template.py
@@ -1,18 +1,14 @@
 """For entities that have templates."""
 from gemd.entity.has_dependencies import HasDependencies
+from gemd.entity.object.has_template_check_generator import HasTemplateCheckGenerator
 from gemd.entity.template.base_template import BaseTemplate
 from gemd.entity.link_by_uid import LinkByUID
-from gemd.entity.bounds_validation import get_validation_level, WarningLevel
-from gemd.entity.dict_serializable import logger
 
 from abc import abstractmethod
-from inspect import getmodule, isclass
-from typing import Optional, Union, Set, Type, Callable, TypeVar
-
-T = TypeVar('T')
+from typing import Optional, Union, Set, Type
 
 
-class HasTemplate(HasDependencies):
+class HasTemplate(HasTemplateCheckGenerator, HasDependencies):
     """Mix-in trait for objects that can be assigned templates.
 
     Parameters
@@ -46,44 +42,6 @@ class HasTemplate(HasDependencies):
         else:
             raise TypeError(f"Template must be a {self._template_type()} or LinkByUID, "
                             f"not {type(template)}")
-
-    def _generate_template_check(self,
-                                 validate: Callable[[Union["HasSpec", "HasTemplate"], T], bool]
-                                 ) -> Callable[[T], T]:
-        """Generate a closure for the object and the validation routine."""
-        from gemd.entity.object.has_spec import HasSpec
-
-        if not isinstance(self, (HasSpec, HasTemplate)):
-            raise ValueError(f"{self} does not support object template checks.")
-
-        module = getmodule(validate)
-        cls = None
-        if module is not None:
-            for member in module.__dict__.values():
-                if isclass(member) and member.__module__ == module.__name__:
-                    cls = member
-                    break
-        if cls is None:
-            raise ValueError(f"Could not map class for function {validate}.")
-        attr = next((y for x, y in validate.__annotations__.items() if x != 'return'), None)
-        if attr is None:
-            raise ValueError(f"Could not map attribute for function {validate}.")
-
-        def template_check(x: attr) -> attr:
-            level = get_validation_level()
-            reject = level != WarningLevel.IGNORE \
-                and isinstance(self.template, cls) \
-                and not validate(self.template, x)
-
-            if reject:
-                message = f"Value {x.value} is inconsistent with template {self.template.name}"
-                if level == WarningLevel.WARNING:
-                    logger.warning(message)
-                else:
-                    raise ValueError(message)
-            return x
-
-        return template_check
 
     def _local_dependencies(self) -> Set[Union["BaseEntity", "LinkByUID"]]:
         """Return a set of all immediate dependencies (no recursion)."""

--- a/gemd/entity/object/has_template.py
+++ b/gemd/entity/object/has_template.py
@@ -1,6 +1,5 @@
 """For entities that have templates."""
 from gemd.entity.has_dependencies import HasDependencies
-from gemd.entity.object.has_template_check_generator import HasTemplateCheckGenerator
 from gemd.entity.template.base_template import BaseTemplate
 from gemd.entity.link_by_uid import LinkByUID
 
@@ -8,7 +7,7 @@ from abc import abstractmethod
 from typing import Optional, Union, Set, Type
 
 
-class HasTemplate(HasTemplateCheckGenerator, HasDependencies):
+class HasTemplate(HasDependencies):
     """Mix-in trait for objects that can be assigned templates.
 
     Parameters

--- a/gemd/entity/object/has_template_check_generator.py
+++ b/gemd/entity/object/has_template_check_generator.py
@@ -1,0 +1,71 @@
+"""For entities that have specs."""
+from gemd.entity.template.base_template import BaseTemplate
+from gemd.entity.link_by_uid import LinkByUID
+from gemd.entity.bounds_validation import get_validation_level, WarningLevel
+from gemd.entity.dict_serializable import logger
+
+from abc import ABC, abstractmethod
+from inspect import getmodule, getmembers, isclass, signature
+from typing import Union, Callable, TypeVar
+
+T = TypeVar('T')
+
+
+class HasTemplateCheckGenerator(ABC):
+    """Mix-in trait for objects that can generate a Check Template closure."""
+
+    @property
+    @abstractmethod
+    def template(self) -> Union[BaseTemplate, LinkByUID]:
+        """Get the object template associated with this object."""
+
+    def _generate_template_check(self,
+                                 validate: Callable[["HasTemplateCheckGenerator", T], bool]
+                                 ) -> Callable[[T], None]:
+        """
+        Generate a closure for the object and the validation routine.
+
+        Parameters
+        ----------
+        validate: function(HasTemplateCheckGenerator, Attribute) -> bool
+            A method that checks if the object template is consistent with the attribute
+
+        Returns
+        -------
+        function(Attribute)
+            If the attribute is inconsistent, ignores, warns or dies based on get_validation_level
+
+        Raises
+        ------
+        ValueError
+            If `value` is not one of the allowed types or if mapping types fails.
+
+        """
+        # Determine which class `validate` is from, so we can type check the object template
+        module = getmodule(validate)  # Get the module that contains `validate`
+        # Get the class that was defined in this module (a.k.a. not imported)
+        cls = next((y for x, y in getmembers(module, isclass) if getmodule(y) == module), None)
+        if cls is None:
+            raise ValueError(f"Could not map class for function {validate}.")
+
+        # Grab the type of validate's argument so we know what kind of attribute we are validating
+        arguments = list(signature(validate).parameters.values())  # List of arguments to validate
+        attr = arguments[1].annotation if len(arguments) == 2 else None  # First self, then attr
+        if attr is None:
+            raise ValueError(f"Could not map attribute for function {validate}.")
+
+        def template_check(x: attr):
+            """Given an attribute, check it against this object's template."""
+            level = get_validation_level()
+            reject = level != WarningLevel.IGNORE \
+                and isinstance(self.template, cls) \
+                and not validate(self.template, x)
+
+            if reject:
+                message = f"Value {x.value} is inconsistent with template {self.template.name}"
+                if level == WarningLevel.WARNING:
+                    logger.warning(message)
+                else:
+                    raise ValueError(message)
+
+        return template_check

--- a/gemd/entity/object/material_spec.py
+++ b/gemd/entity/object/material_spec.py
@@ -1,6 +1,7 @@
 from gemd.entity.attribute.property_and_conditions import PropertyAndConditions
 from gemd.entity.object.base_object import BaseObject
 from gemd.entity.object.has_template import HasTemplate
+from gemd.entity.template.has_property_templates import HasPropertyTemplates
 from gemd.entity.setters import validate_list
 from gemd.entity.bounds_validation import get_validation_level, WarningLevel
 from gemd.entity.dict_serializable import logger
@@ -64,7 +65,8 @@ class MaterialSpec(BaseObject, HasTemplate):
             # if Has_Templates hasn't been called yet, it won't have a _template attribute
             template = getattr(self, "template", None)
             level = get_validation_level()
-            accept = level == WarningLevel.IGNORE or template is None \
+            accept = level == WarningLevel.IGNORE \
+                or not isinstance(template, HasPropertyTemplates) \
                 or self.template.validate_property(x)
 
             if not accept:

--- a/gemd/entity/object/material_spec.py
+++ b/gemd/entity/object/material_spec.py
@@ -2,6 +2,7 @@ from gemd.entity.attribute.property_and_conditions import PropertyAndConditions
 from gemd.entity.object.process_spec import ProcessSpec
 from gemd.entity.object.base_object import BaseObject
 from gemd.entity.object.has_process import HasProcess
+from gemd.entity.object.has_properties import HasProperties
 from gemd.entity.object.has_template import HasTemplate
 from gemd.entity.template.has_property_templates import HasPropertyTemplates
 from gemd.entity.template.material_template import MaterialTemplate
@@ -12,7 +13,7 @@ from gemd.entity.setters import validate_list
 from typing import Optional, Union, Iterable, List, Set, Mapping, Type
 
 
-class MaterialSpec(BaseObject, HasTemplate, HasProcess):
+class MaterialSpec(BaseObject, HasTemplate, HasProcess, HasProperties):
     """
     A material specification.
 

--- a/gemd/entity/object/measurement_spec.py
+++ b/gemd/entity/object/measurement_spec.py
@@ -11,7 +11,7 @@ from gemd.entity.link_by_uid import LinkByUID
 from typing import Optional, Union, Iterable, Mapping, Type
 
 
-class MeasurementSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
+class MeasurementSpec(BaseObject, HasTemplate, HasParameters, HasConditions):
     """
     A measurement specification.
 
@@ -59,9 +59,9 @@ class MeasurementSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
                  file_links: Optional[Union[Iterable[FileLink], FileLink]] = None):
         BaseObject.__init__(self, name=name, uids=uids, tags=tags, notes=notes,
                             file_links=file_links)
+        HasTemplate.__init__(self, template=template)
         HasParameters.__init__(self, parameters=parameters)
         HasConditions.__init__(self, conditions=conditions)
-        HasTemplate.__init__(self, template=template)
 
     @staticmethod
     def _template_type() -> Type:

--- a/gemd/entity/object/process_spec.py
+++ b/gemd/entity/object/process_spec.py
@@ -12,7 +12,7 @@ from gemd.entity.setters import validate_list
 from typing import Optional, Union, Iterable, List, Mapping, Dict, Type, Any
 
 
-class ProcessSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
+class ProcessSpec(BaseObject, HasTemplate, HasParameters, HasConditions):
     """
     A process specification.
 
@@ -76,9 +76,9 @@ class ProcessSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
 
         BaseObject.__init__(self, name=name, uids=uids, tags=tags, notes=notes,
                             file_links=file_links)
+        HasTemplate.__init__(self, template=template)
         HasParameters.__init__(self, parameters=parameters)
         HasConditions.__init__(self, conditions=conditions)
-        HasTemplate.__init__(self, template=template)
 
         # By default, a ProcessSpec is not linked to any MaterialSpec.
         # If a MaterialSpec is linked to this ProcessSpec,

--- a/gemd/entity/object/tests/test_ingredient_spec.py
+++ b/gemd/entity/object/tests/test_ingredient_spec.py
@@ -9,7 +9,7 @@ from gemd.entity.value.normal_real import NormalReal
 from gemd.entity.value.nominal_integer import NominalInteger
 from gemd.entity.value.nominal_categorical import NominalCategorical
 from gemd.entity.value.empirical_formula import EmpiricalFormula
-from gemd.entity.bounds_validation import validation_context, WarningLevel
+from gemd.entity.bounds_validation import validation_level, WarningLevel
 
 
 def test_ingredient_reassignment():
@@ -56,7 +56,7 @@ def test_valid_quantities(valid_quantity, caplog):
     There are no restrictions on the value or the units. Although a volume fraction of -5 kg
     does not make physical sense, it will not throw an error.
     """
-    with validation_context(WarningLevel.IGNORE):
+    with validation_level(WarningLevel.IGNORE):
         ingred = IngredientSpec(name="name", mass_fraction=valid_quantity)
         assert ingred.mass_fraction == valid_quantity
         ingred = IngredientSpec(name="name", volume_fraction=valid_quantity)
@@ -70,14 +70,14 @@ def test_valid_quantities(valid_quantity, caplog):
 
 def test_validation_control(caplog):
     """Verify that when validation is requested, limits are enforced."""
-    with validation_context(WarningLevel.WARNING):
+    with validation_level(WarningLevel.WARNING):
         IngredientSpec(name="name", mass_fraction=NominalReal(0.5, ''))
         assert len(caplog.records) == 0, "Warned on valid values with WARNING."
         IngredientSpec(name="name", mass_fraction=NominalReal(5, ''))
         assert len(caplog.records) == 1, "Didn't warn on invalid values with WARNING."
         IngredientSpec(name="name", mass_fraction=NominalReal(0.5, 'm'))
         assert len(caplog.records) == 2, "Didn't warn on invalid units with WARNING."
-    with validation_context(WarningLevel.FATAL):
+    with validation_level(WarningLevel.FATAL):
         # The following should not raise an exception
         IngredientSpec(name="name", mass_fraction=NominalReal(0.5, ''))
         with pytest.raises(ValueError):

--- a/gemd/entity/object/tests/test_material_spec.py
+++ b/gemd/entity/object/tests/test_material_spec.py
@@ -6,7 +6,7 @@ from gemd.entity.bounds import IntegerBounds
 from gemd.entity.object import ProcessSpec, MaterialSpec
 from gemd.entity.template import MaterialTemplate, PropertyTemplate, ConditionTemplate
 from gemd.entity.value import NominalInteger
-from gemd.entity.bounds_validation import validation_context, WarningLevel
+from gemd.entity.bounds_validation import validation_level, WarningLevel
 
 
 def test_process_reassignment():
@@ -52,21 +52,21 @@ def test_mat_spec_properties(caplog):
         property=Property("Name", value=NominalInteger(1), template=prop_tmpl),
         conditions=[Condition("Name", value=NominalInteger(2), template=cond_tmpl)]
     )
-    with validation_context(WarningLevel.IGNORE):
+    with validation_level(WarningLevel.IGNORE):
         mat_spec.properties.append(good_prop)
         assert len(caplog.records) == 0, "Warning encountered on IGNORE"
         mat_spec.properties.append(bad_prop)
         assert len(caplog.records) == 0, "Warning encountered on IGNORE"
         mat_spec.properties.append(bad_cond)
         assert len(caplog.records) == 0, "Warning encountered on IGNORE"
-    with validation_context(WarningLevel.WARNING):
+    with validation_level(WarningLevel.WARNING):
         mat_spec.properties.append(good_prop)
         assert len(caplog.records) == 0, "Warning encountered on Good value"
         mat_spec.properties.append(bad_prop)
         assert len(caplog.records) == 1, "No warning encountered on Bad Value"
         mat_spec.properties.append(bad_cond)
         assert len(caplog.records) == 1, "Warning encountered on Bad condition"
-    with validation_context(WarningLevel.FATAL):
+    with validation_level(WarningLevel.FATAL):
         mat_spec.properties.append(good_prop)  # This is fine
         with pytest.raises(ValueError):
             mat_spec.properties.append(bad_prop)

--- a/gemd/entity/object/tests/test_measurement_run.py
+++ b/gemd/entity/object/tests/test_measurement_run.py
@@ -7,7 +7,6 @@ from gemd.entity.bounds import IntegerBounds
 from gemd.entity.object import MeasurementRun, MaterialRun
 from gemd.entity.object.measurement_spec import MeasurementSpec
 from gemd.entity.attribute import Condition, Parameter, Property
-from gemd.entity.template import ConditionTemplate, ParameterTemplate, PropertyTemplate
 from gemd.entity.source.performed_source import PerformedSource
 from gemd.entity.template import MeasurementTemplate, PropertyTemplate, ParameterTemplate, \
     ConditionTemplate
@@ -15,7 +14,7 @@ from gemd.entity.value import NominalReal, NominalInteger
 from gemd.entity.file_link import FileLink
 from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.bounds import RealBounds
-from gemd.entity.bounds_validation import validation_context, WarningLevel
+from gemd.entity.bounds_validation import validation_level, WarningLevel
 from gemd.util.impl import substitute_links
 
 
@@ -138,19 +137,19 @@ def test_template_validations(caplog):
     )
     msr_spec = MeasurementSpec("Measurement Spec", template=msr_tmpl)
     msr_run = MeasurementRun("MeasurementRun", spec=msr_spec)
-    with validation_context(WarningLevel.IGNORE):
+    with validation_level(WarningLevel.IGNORE):
         msr_run.properties.append(Property("Name", value=NominalReal(-1, "")))
         msr_run.conditions.append(Condition("Name", value=NominalReal(-1, "")))
         msr_run.parameters.append(Parameter("Name", value=NominalReal(-1, "")))
         assert len(caplog.records) == 0, "Logging records wasn't empty"
-    with validation_context(WarningLevel.WARNING):
+    with validation_level(WarningLevel.WARNING):
         msr_run.properties.append(Property("Name", value=NominalReal(-1, "")))
         assert len(caplog.records) == 1, "WARNING didn't warn on invalid Property."
         msr_run.conditions.append(Condition("Name", value=NominalReal(-1, "")))
         assert len(caplog.records) == 2, "WARNING didn't warn on invalid Condition."
         msr_run.parameters.append(Parameter("Name", value=NominalReal(-1, "")))
         assert len(caplog.records) == 3, "WARNING didn't warn on invalid Parameter."
-    with validation_context(WarningLevel.FATAL):
+    with validation_level(WarningLevel.FATAL):
         with pytest.raises(ValueError):
             msr_run.properties.append(Property("Name", value=NominalReal(-1, "")))
         with pytest.raises(ValueError):

--- a/gemd/entity/object/tests/test_process_spec.py
+++ b/gemd/entity/object/tests/test_process_spec.py
@@ -3,8 +3,9 @@ import pytest
 from copy import deepcopy
 
 from gemd.json import dumps, loads
-from gemd.entity.attribute import PropertyAndConditions, Property
+from gemd.entity.attribute import PropertyAndConditions, Property, Parameter
 from gemd.entity.object import ProcessSpec, MaterialSpec, IngredientSpec
+from gemd.entity.template.has_parameter_templates import HasParameterTemplates
 from gemd.entity.value import DiscreteCategorical
 from gemd.util import flatten
 
@@ -82,3 +83,16 @@ def test_equality():
 
     spec5 = next(x for x in flatten(spec4, 'test-scope') if isinstance(x, ProcessSpec))
     assert spec5 == spec4, "Flattening removes measurement references, but that's okay"
+
+
+def test_template_check_generator():
+    """Verify that the generator throws exceptions."""
+    with pytest.raises(ValueError):  # self can't template
+        ProcessSpec._generate_template_check(self=Parameter("An entity without a template"),
+                                             validate=HasParameterTemplates.validate_parameter)
+    spec1 = ProcessSpec("A spec")
+    with pytest.raises(ValueError):  # Can't find class
+        spec1._generate_template_check(validate=lambda x, y: True)
+
+    with pytest.raises(ValueError):  # Can't find attribute
+        spec1._generate_template_check(validate=ProcessSpec.name.fget)

--- a/gemd/entity/object/tests/test_process_spec.py
+++ b/gemd/entity/object/tests/test_process_spec.py
@@ -3,9 +3,8 @@ import pytest
 from copy import deepcopy
 
 from gemd.json import dumps, loads
-from gemd.entity.attribute import PropertyAndConditions, Property, Parameter
+from gemd.entity.attribute import PropertyAndConditions, Property
 from gemd.entity.object import ProcessSpec, MaterialSpec, IngredientSpec
-from gemd.entity.template.has_parameter_templates import HasParameterTemplates
 from gemd.entity.value import DiscreteCategorical
 from gemd.util import flatten
 

--- a/gemd/entity/object/tests/test_process_spec.py
+++ b/gemd/entity/object/tests/test_process_spec.py
@@ -87,9 +87,6 @@ def test_equality():
 
 def test_template_check_generator():
     """Verify that the generator throws exceptions."""
-    with pytest.raises(ValueError):  # self can't template
-        ProcessSpec._generate_template_check(self=Parameter("An entity without a template"),
-                                             validate=HasParameterTemplates.validate_parameter)
     spec1 = ProcessSpec("A spec")
     with pytest.raises(ValueError):  # Can't find class
         spec1._generate_template_check(validate=lambda x, y: True)

--- a/gemd/entity/template/has_condition_templates.py
+++ b/gemd/entity/template/has_condition_templates.py
@@ -71,9 +71,9 @@ class HasConditionTemplates(object):
             attr, bnd = next((x for x in self.conditions if condition.name == x[0].name),
                              (None, None))
 
-        if attr is None:
-            return True  # Nothing to check against
-        elif bnd is None:
+        if bnd is not None:
+            return bnd.contains(condition.value)
+        elif attr is not None and isinstance(attr, ConditionTemplate):
             return attr.bounds.contains(condition.value)
         else:
-            return bnd.contains(condition.value)
+            return True  # Nothing to check against

--- a/gemd/entity/template/has_parameter_templates.py
+++ b/gemd/entity/template/has_parameter_templates.py
@@ -70,9 +70,9 @@ class HasParameterTemplates(object):
             attr, bnd = next((x for x in self.parameters if parameter.name == x[0].name),
                              (None, None))
 
-        if attr is None:
-            return True  # Nothing to check against
-        elif bnd is None:
+        if bnd is not None:
+            return bnd.contains(parameter.value)
+        elif attr is not None and isinstance(attr, ParameterTemplate):
             return attr.bounds.contains(parameter.value)
         else:
-            return bnd.contains(parameter.value)
+            return True  # Nothing to check against

--- a/gemd/entity/template/has_parameter_templates.py
+++ b/gemd/entity/template/has_parameter_templates.py
@@ -83,7 +83,6 @@ class HasParameterTemplates(HasDependencies):
         else:
             return True  # Nothing to check against
 
-
     def _local_dependencies(self) -> Set[Union["BaseEntity", "LinkByUID"]]:
         """Return a set of all immediate dependencies (no recursion)."""
         return {attr[0] for attr in self.parameters}

--- a/gemd/entity/template/has_property_templates.py
+++ b/gemd/entity/template/has_property_templates.py
@@ -63,7 +63,6 @@ class HasPropertyTemplates(HasDependencies):
                                          trigger=BaseTemplate._homogenize_ranges
                                          )
 
-
     def validate_property(self, prop: Union["Property", "PropertyAndConditions"]) -> bool:
         """Check if the property is consistent w/ this template."""
         from gemd.entity.attribute import PropertyAndConditions
@@ -83,7 +82,6 @@ class HasPropertyTemplates(HasDependencies):
             return attr.bounds.contains(prop.value)
         else:
             return True  # Nothing to check against
-
 
     def _local_dependencies(self) -> Set[Union["BaseEntity", "LinkByUID"]]:
         """Return a set of all immediate dependencies (no recursion)."""

--- a/gemd/entity/template/has_property_templates.py
+++ b/gemd/entity/template/has_property_templates.py
@@ -74,9 +74,9 @@ class HasPropertyTemplates(object):
             attr, bnd = next((x for x in self.properties if prop.name == x[0].name),
                              (None, None))
 
-        if attr is None:
-            return True  # Nothing to check against
-        elif bnd is None:
+        if bnd is not None:
+            return bnd.contains(prop.value)
+        elif attr is not None and isinstance(attr, PropertyTemplate):
             return attr.bounds.contains(prop.value)
         else:
-            return bnd.contains(prop.value)
+            return True  # Nothing to check against

--- a/gemd/entity/tests/test_bounds_validation.py
+++ b/gemd/entity/tests/test_bounds_validation.py
@@ -1,10 +1,10 @@
 from gemd.entity.bounds_validation import WarningLevel, set_validation_level, \
-    get_validation_level, validation_context
+    get_validation_level, validation_level
 
 
 def test_bounds_validation():
     """Verify that changes to validation level behave as expected."""
-    with validation_context(WarningLevel.IGNORE) as old_level:
+    with validation_level(WarningLevel.IGNORE) as old_level:
         assert get_validation_level() == WarningLevel.IGNORE, "Context worked."
         set_validation_level(WarningLevel.WARNING)
         assert get_validation_level() == WarningLevel.WARNING, "Setter worked."

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.4.1',
+      version='1.7.0',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Citrine Informatics',


### PR DESCRIPTION
Right now, all validation is performed server side with no constraints or feedback to users client side when types or values are inconsistent with templates.  This PR does two things:

1. It adds automatic validation code at every level of value assignment so that a user can receive feedback immediately when a bound is violated.
2. It adds the ability for the user to control whether the inconsistencies with bounds are ignored, are a warning, or are fatal.  The default here is Warning, which will make existing scripts noisier but will not break existing workflows.  It is proposed that we consider changing the default to Fatal when we release gemd-python 2.0.

Note that there is no guarantee that an object can be validated since any template could just be referenced by LinkByUID,  in which case we have no local knowledge of its bounds.