### PR TITLE
Feature/pla 8803 add integer units

### DIFF
--- a/gemd/builders/impl.py
+++ b/gemd/builders/impl.py
@@ -321,7 +321,7 @@ def make_value(value: Union[str, float, int],
     if isinstance(bounds, RealBounds):
         result = NominalReal(value, units=bounds.default_units)
     elif isinstance(bounds, IntegerBounds):
-        result = NominalInteger(value)
+        result = NominalInteger(value, units=bounds.default_units)
     elif isinstance(bounds, CategoricalBounds):
         result = NominalCategorical(value)
     elif isinstance(bounds, CompositionBounds):

--- a/gemd/entity/bounds/base_bounds.py
+++ b/gemd/entity/bounds/base_bounds.py
@@ -5,6 +5,8 @@ from typing import Union
 import gemd.units as units
 from gemd.entity.dict_serializable import DictSerializable
 
+DIMENSIONLESS = "dimensionless"
+
 
 class BaseBounds(DictSerializable):
     """Base class for bounds, including RealBounds and CategoricalBounds."""

--- a/gemd/entity/bounds/base_bounds.py
+++ b/gemd/entity/bounds/base_bounds.py
@@ -2,6 +2,7 @@
 from abc import abstractmethod
 from typing import Union
 
+import gemd.units as units
 from gemd.entity.dict_serializable import DictSerializable
 
 
@@ -34,3 +35,36 @@ class BaseBounds(DictSerializable):
         if isinstance(bounds, BaseBounds):
             return True
         raise TypeError('{} is not a Bounds object'.format(bounds))
+
+
+def convert_bounds(lower_bound, upper_bound, source_units, target_units):
+    """
+    Convert the bounds to the target unit system, or None if not possible.
+
+    Parameters
+    ----------
+    lower_bound: float
+        Lower endpoint.
+    upper_bound: float
+        Upper endpoint.
+    source_units: str
+        A string describing the source units. Units must be present and they must
+        be parseable by Pint. An empty string can be used for the units of a
+        dimensionless quantity.
+    target_units: str
+        The units to convert into.
+
+    Returns
+    -------
+    tuple (float, float)
+        A tuple of the (lower_bound, upper_bound) in the target units.
+
+    """
+    try:
+        lower_bound = units.convert_units(
+            lower_bound, source_units, target_units)
+        upper_bound = units.convert_units(
+            upper_bound, source_units, target_units)
+        return lower_bound, upper_bound
+    except units.IncompatibleUnitsError:
+        return None, None

--- a/gemd/entity/bounds/integer_bounds.py
+++ b/gemd/entity/bounds/integer_bounds.py
@@ -17,7 +17,7 @@ class IntegerBounds(BaseBounds):
         Lower endpoint.
     upper_bound: int
         Upper endpoint.
-    default_units: str
+    default_units: optional[str]
         An optional string describing the units that must be parseable by Pint, if supplied.
         If this argument is not supplied, an empty string will be used for the units of a
         dimensionless quantity.

--- a/gemd/entity/bounds/integer_bounds.py
+++ b/gemd/entity/bounds/integer_bounds.py
@@ -17,14 +17,15 @@ class IntegerBounds(BaseBounds):
         Upper endpoint.
     default_units: optional[str]
         An optional string describing the units that must be parseable by Pint, if supplied.
-        If this argument is not supplied, an empty string will be used for the units of a
-        dimensionless quantity.
+        If this argument is not supplied, the 'dimensionless' string will be used for the
+        units of a dimensionless quantity.  If an empty string is used, it will be converted
+        to 'dimensionless'.
 
     """
 
     typ = "integer_bounds"
 
-    def __init__(self, lower_bound=None, upper_bound=None, default_units=''):
+    def __init__(self, lower_bound=None, upper_bound=None, default_units=DIMENSIONLESS):
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
 
@@ -49,7 +50,7 @@ class IntegerBounds(BaseBounds):
     def default_units(self, default_units):
         if default_units is None:
             raise ValueError("Integer bounds must have units. "
-                             "Use 'default_units=None' for the default dimensionless quantity.")
+                             "Use default_units='' for the default dimensionless quantity.")
         self._default_units = units.parse_units(default_units)
 
     def contains(self, bounds: Union[BaseBounds, "BaseValue"]) -> bool:

--- a/gemd/entity/bounds/integer_bounds.py
+++ b/gemd/entity/bounds/integer_bounds.py
@@ -19,13 +19,14 @@ class IntegerBounds(BaseBounds):
         Upper endpoint.
     default_units: str
         An optional string describing the units that must be parseable by Pint, if supplied.
-        If this argument is not supplied, the 'dimensionless' string will be used.
+        If this argument is not supplied, an empty string will be used for the units of a
+        dimensionless quantity.
 
     """
 
     typ = "integer_bounds"
 
-    def __init__(self, lower_bound=None, upper_bound=None, default_units=DIMENSIONLESS):
+    def __init__(self, lower_bound=None, upper_bound=None, default_units=''):
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
 

--- a/gemd/entity/bounds/integer_bounds.py
+++ b/gemd/entity/bounds/integer_bounds.py
@@ -1,10 +1,8 @@
 """Bounds an integer to be between two values."""
-from gemd.entity.bounds.base_bounds import BaseBounds, convert_bounds
+from gemd.entity.bounds.base_bounds import BaseBounds, convert_bounds, DIMENSIONLESS
 import gemd.units as units
 
 from typing import Union
-
-DIMENSIONLESS = "dimensionless"
 
 
 class IntegerBounds(BaseBounds):
@@ -85,7 +83,5 @@ class IntegerBounds(BaseBounds):
 
         lower, upper = convert_bounds(self.lower_bound, self.upper_bound,
                                       self.default_units, bounds.default_units)
-        if lower is None:
-            return False
 
         return bounds.lower_bound >= int(lower) and bounds.upper_bound <= int(upper)

--- a/gemd/entity/bounds/integer_bounds.py
+++ b/gemd/entity/bounds/integer_bounds.py
@@ -1,7 +1,10 @@
 """Bounds an integer to be between two values."""
-from gemd.entity.bounds.base_bounds import BaseBounds
+from gemd.entity.bounds.base_bounds import BaseBounds, convert_bounds
+import gemd.units as units
 
 from typing import Union
+
+DIMENSIONLESS = "dimensionless"
 
 
 class IntegerBounds(BaseBounds):
@@ -14,14 +17,20 @@ class IntegerBounds(BaseBounds):
         Lower endpoint.
     upper_bound: int
         Upper endpoint.
+    default_units: str
+        An optional string describing the units that must be parseable by Pint, if supplied.
+        If this argument is not supplied, the 'dimensionless' string will be used.
 
     """
 
     typ = "integer_bounds"
 
-    def __init__(self, lower_bound=None, upper_bound=None):
+    def __init__(self, lower_bound=None, upper_bound=None, default_units=DIMENSIONLESS):
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
+
+        self._default_units = None
+        self.default_units = default_units
 
         if self.lower_bound is None or abs(self.lower_bound) >= float("inf"):
             raise ValueError("Lower bound must be given and finite: {}".format(self.lower_bound))
@@ -31,6 +40,18 @@ class IntegerBounds(BaseBounds):
 
         if self.upper_bound < self.lower_bound:
             raise ValueError("Upper bound must be greater than or equal to lower bound")
+
+    @property
+    def default_units(self):
+        """Get default units."""
+        return self._default_units
+
+    @default_units.setter
+    def default_units(self, default_units):
+        if default_units is None:
+            raise ValueError("Integer bounds must have units. "
+                             "Use 'default_units=None' for the default dimensionless quantity.")
+        self._default_units = units.parse_units(default_units)
 
     def contains(self, bounds: Union[BaseBounds, "BaseValue"]) -> bool:
         """
@@ -58,5 +79,12 @@ class IntegerBounds(BaseBounds):
             bounds = bounds._to_bounds()
         if not isinstance(bounds, IntegerBounds):
             return False
+        if (bounds.default_units == DIMENSIONLESS) ^ (self.default_units == DIMENSIONLESS):
+            raise ValueError("Unit mismatch, cannot compare dimensional and dimensionless bounds")
 
-        return bounds.lower_bound >= self.lower_bound and bounds.upper_bound <= self.upper_bound
+        lower, upper = convert_bounds(self.lower_bound, self.upper_bound,
+                                      self.default_units, bounds.default_units)
+        if lower is None:
+            return False
+
+        return bounds.lower_bound >= int(lower) and bounds.upper_bound <= int(upper)

--- a/gemd/entity/bounds/real_bounds.py
+++ b/gemd/entity/bounds/real_bounds.py
@@ -79,8 +79,6 @@ class RealBounds(BaseBounds):
             bounds = bounds._to_bounds()
         if not isinstance(bounds, RealBounds):
             return False
-        if (not bounds.default_units) ^ (not self.default_units):
-            raise ValueError("Unit mismatch, cannot compare dimensional and dimensionless bounds")
 
         lower, upper = convert_bounds(self.lower_bound, self.upper_bound,
                                       self.default_units, bounds.default_units)

--- a/gemd/entity/bounds/real_bounds.py
+++ b/gemd/entity/bounds/real_bounds.py
@@ -1,5 +1,5 @@
 """Bound a real number to be between two values."""
-from gemd.entity.bounds.base_bounds import BaseBounds
+from gemd.entity.bounds.base_bounds import BaseBounds, convert_bounds
 import gemd.units as units
 
 from typing import Union
@@ -79,33 +79,12 @@ class RealBounds(BaseBounds):
             bounds = bounds._to_bounds()
         if not isinstance(bounds, RealBounds):
             return False
+        if (not bounds.default_units) ^ (not self.default_units):
+            raise ValueError("Unit mismatch, cannot compare dimensional and dimensionless bounds")
 
-        lower, upper = self._convert_bounds(bounds.default_units)
+        lower, upper = convert_bounds(self.lower_bound, self.upper_bound,
+                                      self.default_units, bounds.default_units)
         if lower is None:
             return False
 
         return bounds.lower_bound >= lower and bounds.upper_bound <= upper
-
-    def _convert_bounds(self, target_units):
-        """
-        Convert the bounds to the target unit system, or None if not possible.
-
-        Parameters
-        ----------
-        target_units: str
-            The units to convert into.
-
-        Returns
-        -------
-        tuple (float, float)
-            A tuple of the (lower_bound, upper_bound) in the target units.
-
-        """
-        try:
-            lower_bound = units.convert_units(
-                self.lower_bound, self.default_units, target_units)
-            upper_bound = units.convert_units(
-                self.upper_bound, self.default_units, target_units)
-            return lower_bound, upper_bound
-        except units.IncompatibleUnitsError:
-            return None, None

--- a/gemd/entity/bounds/tests/test_integer_bounds.py
+++ b/gemd/entity/bounds/tests/test_integer_bounds.py
@@ -39,3 +39,17 @@ def test_contains():
 
     assert int_bounds.contains(NominalInteger(1))
     assert not int_bounds.contains(NominalInteger(5))
+
+
+def test_default_units():
+    """Test optional default units"""
+    units = "meter"
+    no_units = IntegerBounds(0, 2)
+    has_units = IntegerBounds(0, 2, default_units=units)
+
+    assert no_units.default_units == "dimensionless"
+    assert has_units.default_units == units
+
+    new_units = "kilometer"
+    has_units.default_units = new_units
+    assert has_units.default_units == new_units

--- a/gemd/entity/bounds/tests/test_integer_bounds.py
+++ b/gemd/entity/bounds/tests/test_integer_bounds.py
@@ -44,10 +44,10 @@ def test_contains():
 def test_contains_with_modified_units():
     """Test optional default units being converted"""
     units = "kilometer"
-    no_units = IntegerBounds(0, 2)
     has_units = IntegerBounds(0, 2, default_units=units)
 
-    assert no_units.default_units == "dimensionless"
+    assert IntegerBounds(0, 2).default_units == "dimensionless"
+    assert IntegerBounds(0, 2, default_units="").default_units == "dimensionless"
     assert has_units.default_units == units
 
     new_units = "meter"

--- a/gemd/entity/bounds/tests/test_integer_bounds.py
+++ b/gemd/entity/bounds/tests/test_integer_bounds.py
@@ -1,7 +1,8 @@
 """Test IntegerBounds."""
 import pytest
 
-from gemd.entity.bounds.integer_bounds import IntegerBounds, DIMENSIONLESS
+from gemd.entity.bounds.integer_bounds import IntegerBounds
+from gemd.entity.bounds.base_bounds import DIMENSIONLESS
 from gemd.entity.bounds.real_bounds import RealBounds
 
 
@@ -42,7 +43,7 @@ def test_contains():
 
 
 def test_contains_with_modified_units():
-    """Test optional default units being converted"""
+    """Test optional default units being converted."""
     units = "kilometer"
     has_units = IntegerBounds(0, 2, default_units=units)
 
@@ -50,13 +51,17 @@ def test_contains_with_modified_units():
     assert IntegerBounds(0, 2, default_units="").default_units == DIMENSIONLESS
     assert has_units.default_units == units
 
+    with pytest.raises(ValueError):
+        bounds = IntegerBounds(0, 2)
+        bounds.default_units = None
+
     new_units = "meter"
     has_units.default_units = new_units
     assert has_units.default_units == new_units
 
 
 def test_contains_units_comparison():
-    """Test optional default units being compared"""
+    """Test optional default units being compared."""
     units = "kilometer"
     bounds = IntegerBounds(0, 2, default_units=units)
 
@@ -64,6 +69,8 @@ def test_contains_units_comparison():
     assert bounds.contains(IntegerBounds(0, 2000, default_units="meter"))
     assert not bounds.contains(IntegerBounds(0, 2001, default_units="meter"))
     assert not bounds.contains(IntegerBounds(-1, 2000, default_units="meter"))
+    assert not bounds.contains(RealBounds(0, 2000, default_units="meter"))
+    assert not bounds.contains(None)
 
     with pytest.raises(ValueError):
         # Cannot compare dimensionless with "kilometers"

--- a/gemd/entity/bounds/tests/test_integer_bounds.py
+++ b/gemd/entity/bounds/tests/test_integer_bounds.py
@@ -1,7 +1,7 @@
 """Test IntegerBounds."""
 import pytest
 
-from gemd.entity.bounds.integer_bounds import IntegerBounds
+from gemd.entity.bounds.integer_bounds import IntegerBounds, DIMENSIONLESS
 from gemd.entity.bounds.real_bounds import RealBounds
 
 
@@ -46,8 +46,8 @@ def test_contains_with_modified_units():
     units = "kilometer"
     has_units = IntegerBounds(0, 2, default_units=units)
 
-    assert IntegerBounds(0, 2).default_units == "dimensionless"
-    assert IntegerBounds(0, 2, default_units="").default_units == "dimensionless"
+    assert IntegerBounds(0, 2).default_units == DIMENSIONLESS
+    assert IntegerBounds(0, 2, default_units="").default_units == DIMENSIONLESS
     assert has_units.default_units == units
 
     new_units = "meter"

--- a/gemd/entity/bounds/tests/test_integer_bounds.py
+++ b/gemd/entity/bounds/tests/test_integer_bounds.py
@@ -41,15 +41,30 @@ def test_contains():
     assert not int_bounds.contains(NominalInteger(5))
 
 
-def test_default_units():
-    """Test optional default units"""
-    units = "meter"
+def test_contains_with_modified_units():
+    """Test optional default units being converted"""
+    units = "kilometer"
     no_units = IntegerBounds(0, 2)
     has_units = IntegerBounds(0, 2, default_units=units)
 
     assert no_units.default_units == "dimensionless"
     assert has_units.default_units == units
 
-    new_units = "kilometer"
+    new_units = "meter"
     has_units.default_units = new_units
     assert has_units.default_units == new_units
+
+
+def test_contains_units_comparison():
+    """Test optional default units being compared"""
+    units = "kilometer"
+    bounds = IntegerBounds(0, 2, default_units=units)
+
+    assert bounds.contains(bounds)
+    assert bounds.contains(IntegerBounds(0, 2000, default_units="meter"))
+    assert not bounds.contains(IntegerBounds(0, 2001, default_units="meter"))
+    assert not bounds.contains(IntegerBounds(-1, 2000, default_units="meter"))
+
+    with pytest.raises(ValueError):
+        # Cannot compare dimensionless with "kilometers"
+        bounds.contains(IntegerBounds(0, 2000))

--- a/gemd/entity/value/nominal_integer.py
+++ b/gemd/entity/value/nominal_integer.py
@@ -50,4 +50,5 @@ class NominalInteger(IntegerValue):
             :class:`bounds <gemd.entity.bounds.integer_bounds.IntegerBounds>`.
 
         """
-        return IntegerBounds(lower_bound=self.nominal, upper_bound=self.nominal, default_units=self.units)
+        return IntegerBounds(lower_bound=self.nominal, upper_bound=self.nominal,
+                             default_units=self.units)

--- a/gemd/entity/value/nominal_integer.py
+++ b/gemd/entity/value/nominal_integer.py
@@ -11,15 +11,16 @@ class NominalInteger(IntegerValue):
     ----------
     nominal: int
         A nominal value--not assumed to be exact.
-    units: str
+    units: optional[str]
         An optional string describing the units that must be parseable by Pint, if supplied.
-        If this argument is not supplied, the 'dimensionless' string will be used.
+        If this argument is not supplied, an empty string will be used for the units of a
+        dimensionless quantity.
 
     """
 
     typ = "nominal_integer"
 
-    def __init__(self, nominal, units="dimensionless"):
+    def __init__(self, nominal, units=""):
         self._nominal = None
         self.nominal = nominal
         self.units = units

--- a/gemd/entity/value/nominal_integer.py
+++ b/gemd/entity/value/nominal_integer.py
@@ -11,14 +11,18 @@ class NominalInteger(IntegerValue):
     ----------
     nominal: int
         A nominal value--not assumed to be exact.
+    units: str
+        An optional string describing the units that must be parseable by Pint, if supplied.
+        If this argument is not supplied, the 'dimensionless' string will be used.
 
     """
 
     typ = "nominal_integer"
 
-    def __init__(self, nominal):
+    def __init__(self, nominal, units="dimensionless"):
         self._nominal = None
         self.nominal = nominal
+        self.units = units
 
     @property
     def nominal(self) -> int:
@@ -45,4 +49,4 @@ class NominalInteger(IntegerValue):
             :class:`bounds <gemd.entity.bounds.integer_bounds.IntegerBounds>`.
 
         """
-        return IntegerBounds(lower_bound=self.nominal, upper_bound=self.nominal)
+        return IntegerBounds(lower_bound=self.nominal, upper_bound=self.nominal, default_units=self.units)

--- a/gemd/entity/value/tests/test_nomial_integer.py
+++ b/gemd/entity/value/tests/test_nomial_integer.py
@@ -19,3 +19,27 @@ def test_contains():
     bounds = IntegerBounds(1, 3)
     assert bounds.contains(NominalInteger(2)._to_bounds())
     assert not bounds.contains(NominalInteger(5)._to_bounds())
+
+
+def test_contains_with_units():
+    """Test that bounds know if a Value is contained within it, including a unit check."""
+    # same units
+    units = "kilometer"
+    bounds_with_units = IntegerBounds(1, 3, default_units=units)
+    assert bounds_with_units.contains(NominalInteger(2, units=units)._to_bounds())
+
+    # Different units, with conversion
+    assert not bounds_with_units.contains(NominalInteger(999, units="meter")._to_bounds())
+    assert bounds_with_units.contains(NominalInteger(1000, units="meter")._to_bounds())
+    assert bounds_with_units.contains(NominalInteger(3000, units="meter")._to_bounds())
+    assert not bounds_with_units.contains(NominalInteger(3001, units="meter")._to_bounds())
+
+    # A dimensionless bounds compared to a dimensional one
+    with pytest.raises(ValueError):
+        bounds_dimensionless = IntegerBounds(1, 3)
+        bounds_dimensionless.contains(NominalInteger(2, units="parsec")._to_bounds())
+
+    # A dimensional bounds compared to a dimensionless one
+    with pytest.raises(ValueError):
+        bounds_dimensionless = IntegerBounds(1, 3, default_units=units)
+        bounds_dimensionless.contains(NominalInteger(2)._to_bounds())

--- a/gemd/entity/value/tests/test_nominal_real.py
+++ b/gemd/entity/value/tests/test_nominal_real.py
@@ -1,4 +1,6 @@
 """Tests of the NominalReal class."""
+import pytest
+
 from gemd.entity.value.nominal_real import NominalReal
 from gemd.entity.bounds import RealBounds
 
@@ -8,3 +10,13 @@ def test_contains():
     bounds = RealBounds(1, 3, 'm')
     assert bounds.contains(NominalReal(200, 'cm')._to_bounds())
     assert not bounds.contains(NominalReal(5, 'm')._to_bounds())
+
+    # A dimensionless bounds compared to a dimensional one
+    with pytest.raises(ValueError):
+        bounds_dimensionless = RealBounds(1, 3)
+        bounds_dimensionless.contains(RealBounds(2, units='parsec')._to_bounds())
+
+    # A dimensional bounds compared to a dimensionless one
+    with pytest.raises(ValueError):
+        bounds_dimensional = RealBounds(1, 3, default_units='m')
+        bounds_dimensional.contains(RealBounds(2)._to_bounds())

--- a/gemd/entity/value/tests/test_nominal_real.py
+++ b/gemd/entity/value/tests/test_nominal_real.py
@@ -1,6 +1,4 @@
 """Tests of the NominalReal class."""
-import pytest
-
 from gemd.entity.value.nominal_real import NominalReal
 from gemd.entity.bounds import RealBounds
 
@@ -8,15 +6,9 @@ from gemd.entity.bounds import RealBounds
 def test_contains():
     """Test that bounds know if a Value is contained within it."""
     bounds = RealBounds(1, 3, 'm')
+    assert not bounds.contains(NominalReal(99, 'cm')._to_bounds())
+    assert bounds.contains(NominalReal(100, 'cm')._to_bounds())
     assert bounds.contains(NominalReal(200, 'cm')._to_bounds())
-    assert not bounds.contains(NominalReal(5, 'm')._to_bounds())
-
-    # A dimensionless bounds compared to a dimensional one
-    with pytest.raises(ValueError):
-        bounds_dimensionless = RealBounds(1, 3)
-        bounds_dimensionless.contains(RealBounds(2, units='parsec')._to_bounds())
-
-    # A dimensional bounds compared to a dimensionless one
-    with pytest.raises(ValueError):
-        bounds_dimensional = RealBounds(1, 3, default_units='m')
-        bounds_dimensional.contains(RealBounds(2)._to_bounds())
+    assert bounds.contains(NominalReal(300, 'cm')._to_bounds())
+    assert not bounds.contains(NominalReal(301, 'cm')._to_bounds())
+    assert not bounds.contains(NominalReal(4, 'm')._to_bounds())

--- a/gemd/entity/value/tests/test_uniform_integer.py
+++ b/gemd/entity/value/tests/test_uniform_integer.py
@@ -30,3 +30,24 @@ def test_contains():
     bounds = IntegerBounds(1, 3)
     assert bounds.contains(UniformInteger(1, 2)._to_bounds())
     assert not bounds.contains(UniformInteger(3, 5)._to_bounds())
+
+def test_contains_units():
+    """Test that bounds unit conversion works"""
+    bounds = IntegerBounds(1, 3)
+    assert bounds.contains(UniformInteger(1, 2)._to_bounds())
+    assert not bounds.contains(UniformInteger(3, 5)._to_bounds())
+
+
+def test_contains_units_comparison():
+    """Test optional default units being compared"""
+    units = "kilometer"
+    bounds = IntegerBounds(0, 2, default_units=units)
+
+    assert bounds.contains(bounds)
+    assert bounds.contains(UniformInteger(0, 2000, units="meter")._to_bounds())
+    assert not bounds.contains(UniformInteger(0, 2001, units="meter")._to_bounds())
+    assert not bounds.contains(UniformInteger(-1, 2000, units="meter")._to_bounds())
+
+    with pytest.raises(ValueError):
+        # Cannot compare dimensionless with "kilometers"
+        bounds.contains(UniformInteger(0, 2000)._to_bounds())

--- a/gemd/entity/value/tests/test_uniform_integer.py
+++ b/gemd/entity/value/tests/test_uniform_integer.py
@@ -31,15 +31,16 @@ def test_contains():
     assert bounds.contains(UniformInteger(1, 2)._to_bounds())
     assert not bounds.contains(UniformInteger(3, 5)._to_bounds())
 
+
 def test_contains_units():
-    """Test that bounds unit conversion works"""
+    """Test that bounds unit conversion works."""
     bounds = IntegerBounds(1, 3)
     assert bounds.contains(UniformInteger(1, 2)._to_bounds())
     assert not bounds.contains(UniformInteger(3, 5)._to_bounds())
 
 
 def test_contains_units_comparison():
-    """Test optional default units being compared"""
+    """Test optional default units being compared."""
     units = "kilometer"
     bounds = IntegerBounds(0, 2, default_units=units)
 

--- a/gemd/entity/value/uniform_integer.py
+++ b/gemd/entity/value/uniform_integer.py
@@ -14,15 +14,16 @@ class UniformInteger(IntegerValue):
         Inclusive lower bound of the distribution.
     upper_bound: int
         Inclusive upper bound of the distribution.
-    units: str
-        An optional string describing the units. If units are supplied, they
-        must be parseable by Pint. By default, "dimensionless" is used.
+    units: optional[str]
+        An optional string describing the units that must be parseable by Pint, if supplied.
+        If this argument is not supplied, an empty string will be used for the units of a
+        dimensionless quantity.
 
     """
 
     typ = "uniform_integer"
 
-    def __init__(self, lower_bound: int, upper_bound: int, units="dimensionless"):
+    def __init__(self, lower_bound: int, upper_bound: int, units=""):
         self._lower_bound = None
         self._upper_bound = None
         self.lower_bound = lower_bound

--- a/gemd/entity/value/uniform_integer.py
+++ b/gemd/entity/value/uniform_integer.py
@@ -1,5 +1,4 @@
 """A uniformly distributed integer value."""
-from gemd import units
 from gemd.entity.value.integer_value import IntegerValue
 from gemd.entity.bounds import IntegerBounds
 
@@ -78,4 +77,5 @@ class UniformInteger(IntegerValue):
             :class:`bounds <gemd.entity.bounds.integer_bounds.IntegerBounds>`.
 
         """
-        return IntegerBounds(lower_bound=self.lower_bound, upper_bound=self.upper_bound, default_units=self.units)
+        return IntegerBounds(lower_bound=self.lower_bound, upper_bound=self.upper_bound,
+                             default_units=self.units)

--- a/gemd/entity/value/uniform_integer.py
+++ b/gemd/entity/value/uniform_integer.py
@@ -1,4 +1,5 @@
 """A uniformly distributed integer value."""
+from gemd import units
 from gemd.entity.value.integer_value import IntegerValue
 from gemd.entity.bounds import IntegerBounds
 
@@ -13,17 +14,20 @@ class UniformInteger(IntegerValue):
         Inclusive lower bound of the distribution.
     upper_bound: int
         Inclusive upper bound of the distribution.
+    units: str
+        An optional string describing the units. If units are supplied, they
+        must be parseable by Pint. By default, "dimensionless" is used.
 
     """
 
     typ = "uniform_integer"
 
-    def __init__(self, lower_bound: int, upper_bound: int):
+    def __init__(self, lower_bound: int, upper_bound: int, units="dimensionless"):
         self._lower_bound = None
         self._upper_bound = None
-
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
+        self.units = units
 
     @property
     def lower_bound(self) -> int:
@@ -73,4 +77,4 @@ class UniformInteger(IntegerValue):
             :class:`bounds <gemd.entity.bounds.integer_bounds.IntegerBounds>`.
 
         """
-        return IntegerBounds(lower_bound=self.lower_bound, upper_bound=self.upper_bound)
+        return IntegerBounds(lower_bound=self.lower_bound, upper_bound=self.upper_bound, default_units=self.units)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.8.1',
+      version='1.9.0',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Citrine Informatics',


### PR DESCRIPTION
This PR adds support for units in the IntegerBounds class.  The AI Engine expects units, so I've added optional support for them.  I will also create a PR for Citrine Python to add support for the IntDescriptor type when this PR is merged.

Discussion points I can think of:

I wasn't sure about raising a ValueError exception when comparing a dimensionless bounds object with a dimensional one.  I'm open to opinions, maybe False is sufficient.

James mentioned it was rare for integer descriptors to use units.  I made the default units an empty string (dimenisonless) if the keyword arg is not supplied.  Units can be supplied at instantiation or modified afterwards.  RealDescriptors require this keyword arg to be supplied, but it seems logical to default to dimensionless if this is the most common use case for integer descriptors.