### PR TITLE
Add ampere-hour to units

### DIFF
--- a/gemd/units/citrine_en.txt
+++ b/gemd/units/citrine_en.txt
@@ -435,6 +435,7 @@ coulomb = ampere * second = C = Coulomb
 abcoulomb = 10 * C = abC
 faraday = e * N_A * mole = _ = Faraday
 conventional_coulomb_90 = K_J90 * R_K90 / (K_J * R_K) * coulomb = C_90
+ampere_hour = ampere * hour = Ah
 
 # Electric potential
 [electric_potential] = [energy] / [charge]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.8.2',
+      version='1.8.3',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Citrine Informatics',


### PR DESCRIPTION
Adding ampere-hour as a unit, as defined in [Pint](https://github.com/hgrecco/pint/blob/82e4fe30aa1890943068afd0610f34e2412d0206/pint/default_en.txt#L405).