### PR TITLE
Move cached_instance to public method

### DIFF
--- a/gemd/util/__init__.py
+++ b/gemd/util/__init__.py
@@ -1,6 +1,8 @@
 # flake8: noqa
-from .impl import set_uuids, make_index, substitute_links, substitute_objects, flatten, \
-    recursive_foreach, recursive_flatmap, writable_sort_order
+from .impl import set_uuids, cached_isinstance, make_index, substitute_links, \
+    substitute_objects, flatten, recursive_foreach, recursive_flatmap, \
+    writable_sort_order
 
-__all__ = ["set_uuids", "make_index", "substitute_links", "substitute_objects", "flatten",
-           "recursive_foreach", "recursive_flatmap", "writable_sort_order"]
+__all__ = ["set_uuids", "cached_isinstance", "make_index", "substitute_links",
+           "substitute_objects", "flatten", "recursive_foreach", "recursive_flatmap",
+           "writable_sort_order"]

--- a/gemd/util/tests/test_cached_isinstance.py
+++ b/gemd/util/tests/test_cached_isinstance.py
@@ -1,0 +1,30 @@
+from gemd.util import cached_isinstance
+
+from typing import List, Iterable
+
+
+def test_cached_isinstance():
+    """Verify that cached_isinstance is operating as exepcted."""
+    passing_pairs = [
+        ("one", str),
+        (1, int),
+        ("one", (str, int)),
+        ([1, 2, 3], List),
+        ("one", Iterable),
+    ]
+    for obj, cls in passing_pairs:
+        assert isinstance(obj, cls) == cached_isinstance(obj, cls)
+        # Twice, for good measure, because we're caching
+        assert isinstance(obj, cls) == cached_isinstance(obj, cls)
+
+    failing_pairs = [
+        ("one", int),
+        (1, str),
+        ("one", (float, int)),
+        ("one", List),
+        (1, Iterable),
+    ]
+    for obj, cls in failing_pairs:
+        assert isinstance(obj, cls) == cached_isinstance(obj, cls)
+        # Twice, for good measure, because we're caching
+        assert isinstance(obj, cls) == cached_isinstance(obj, cls)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.8.5',
+      version='1.9.0',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Citrine Informatics',


### PR DESCRIPTION
In anticipation of releasing citrine-python v1.31, moving a private method that citrine-python references to a public method.

https://github.com/CitrineInformatics/citrine-python/blob/568a03de0c7f45f7be6ea80f029e51fa6eff70ed/src/citrine/_serialization/properties.py#L13

No prior public release of citrine-python references this method.