### PR TITLE
Add union and update methods to bounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: python
 dist: bionic
 python:
 - '3.6'
-- '3.7'
-- '3.8'
+- '3.7.13'
+- '3.8.13'
 - '3.9'
 - '3.10.1'
 install:

--- a/gemd/builders/tests/test_builders.py
+++ b/gemd/builders/tests/test_builders.py
@@ -13,6 +13,7 @@ from gemd.entity.link_by_uid import LinkByUID
 from gemd.units import parse_units
 
 import pytest
+from typing import Union
 
 
 class UnsupportedBounds(BaseBounds):
@@ -20,7 +21,15 @@ class UnsupportedBounds(BaseBounds):
 
     def contains(self, bounds):  # pragma: no cover
         """Only here to satisfy abstract method."""
-        super().contains(bounds)
+        pass
+
+    def union(self, *others: Union["BaseBounds", "BaseValue"]) -> "BaseBounds":  # pragma: no cover
+        """Only here to satisfy abstract method."""
+        pass
+
+    def update(self, *others: Union["BaseBounds", "BaseValue"]):  # pragma: no cover
+        """Only here to satisfy abstract method."""
+        pass
 
 
 class UnsupportedAttribute(BaseAttribute):

--- a/gemd/entity/bounds/base_bounds.py
+++ b/gemd/entity/bounds/base_bounds.py
@@ -34,3 +34,38 @@ class BaseBounds(DictSerializable):
         if isinstance(bounds, BaseBounds):
             return True
         raise TypeError('{} is not a Bounds object'.format(bounds))
+
+    @abstractmethod
+    def union(self, *others: Union["BaseBounds", "BaseValue"]) -> "BaseBounds":
+        """
+        Return the union of this bounds and other bounds.
+
+        The others list must also be the same class (e.g., categorical, real...).
+
+        Parameters
+        ----------
+        others: Union[BaseBounds, BaseValue]
+            Other bounds or value objects to include.
+
+        Returns
+        -------
+        BaseBounds
+            The union of this bounds and the passed bounds
+
+        """
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def update(self, *others: Union["BaseBounds", "BaseValue"]):
+        """
+        Update this bounds to include other bounds.
+
+        The others list must also be the same class (e.g., categorical, real...).
+
+        Parameters
+        ----------
+        others: Union[BaseBounds, BaseValue]
+            Other bounds or value objects to include.
+
+        """
+        pass  # pragma: no cover

--- a/gemd/entity/bounds/categorical_bounds.py
+++ b/gemd/entity/bounds/categorical_bounds.py
@@ -95,7 +95,8 @@ class CategoricalBounds(BaseBounds):
             misses = {type(x).__name__
                       for x in others
                       if not isinstance(x, (CategoricalBounds, CategoricalValue))}
-            raise TypeError(f"union requires consistent typing; found {misses}")
+            raise TypeError(f"union requires consistent typing; "
+                            f"expected categorical, found {misses}")
         result = self.categories.copy()
         for bounds in others:
             if isinstance(bounds, CategoricalValue):

--- a/gemd/entity/bounds/categorical_bounds.py
+++ b/gemd/entity/bounds/categorical_bounds.py
@@ -2,7 +2,7 @@
 from gemd.entity.bounds.base_bounds import BaseBounds
 from gemd.entity.util import array_like
 
-from typing import Union
+from typing import Union, Set, Optional, Iterable
 
 
 class CategoricalBounds(BaseBounds):
@@ -18,17 +18,17 @@ class CategoricalBounds(BaseBounds):
 
     typ = "categorical_bounds"
 
-    def __init__(self, categories=None):
+    def __init__(self, categories: Optional[Iterable[str]] = None):
         self._categories = None
         self.categories = categories
 
     @property
-    def categories(self):
+    def categories(self) -> Set[str]:
         """Get the set of categories."""
         return self._categories
 
     @categories.setter
-    def categories(self, categories):
+    def categories(self, categories: Optional[Iterable[str]]):
         if categories is None:
             self._categories = set()
         elif isinstance(categories, array_like()):
@@ -69,6 +69,53 @@ class CategoricalBounds(BaseBounds):
             return False
 
         return bounds.categories.issubset(self.categories)
+
+    def union(self,
+              *others: Union["CategoricalBounds", "CategoricalValue"]
+              ) -> "CategoricalBounds":
+        """
+        Return the union of this bounds and other bounds.
+
+        The others list must also be Categorical Bounds or Values.
+
+        Parameters
+        ----------
+        others: Union[CategoricalBounds, CategoricalValue]
+            Other bounds or value objects to include.
+
+        Returns
+        -------
+        CategoricalBounds
+            The union of this bounds and the passed bounds
+
+        """
+        from gemd.entity.value.categorical_value import CategoricalValue
+
+        if any(not isinstance(x, (CategoricalBounds, CategoricalValue)) for x in others):
+            misses = {type(x).__name__
+                      for x in others
+                      if not isinstance(x, (CategoricalBounds, CategoricalValue))}
+            raise TypeError(f"union requires consistent typing; found {misses}")
+        result = self.categories.copy()
+        for bounds in others:
+            if isinstance(bounds, CategoricalValue):
+                bounds = bounds._to_bounds()
+            result.update(bounds.categories)
+        return CategoricalBounds(result)
+
+    def update(self, *others: Union["CategoricalBounds", "CategoricalValue"]):
+        """
+        Update this bounds to include other bounds.
+
+        The others list must also be Categorical Bounds or Values.
+
+        Parameters
+        ----------
+        others: Union[CategoricalBounds, CategoricalValue]
+            Other bounds or value objects to include.
+
+        """
+        self.categories = self.union(*others).categories
 
     def as_dict(self):
         """

--- a/gemd/entity/bounds/composition_bounds.py
+++ b/gemd/entity/bounds/composition_bounds.py
@@ -95,7 +95,8 @@ class CompositionBounds(BaseBounds):
             misses = {type(x).__name__
                       for x in others
                       if not isinstance(x, (CompositionBounds, CompositionValue))}
-            raise TypeError(f"union requires consistent typing; found {misses}")
+            raise TypeError(f"union requires consistent typing; "
+                            f"expected composition, found {misses}")
         result = self.components.copy()
         for bounds in others:
             if isinstance(bounds, CompositionValue):

--- a/gemd/entity/bounds/composition_bounds.py
+++ b/gemd/entity/bounds/composition_bounds.py
@@ -70,6 +70,53 @@ class CompositionBounds(BaseBounds):
 
         return bounds.components.issubset(self.components)
 
+    def union(self,
+              *others: Union["CompositionBounds", "CompositionValue"]
+              ) -> "CompositionBounds":
+        """
+        Return the union of this bounds and other bounds.
+
+        The others list must also be Composition Bounds or Values.
+
+        Parameters
+        ----------
+        others: Union[CompositionBounds, CompositionValue]
+            Other bounds or value objects to include.
+
+        Returns
+        -------
+        CategoricalBounds
+            The union of this bounds and the passed bounds
+
+        """
+        from gemd.entity.value.composition_value import CompositionValue
+
+        if any(not isinstance(x, (CompositionBounds, CompositionValue)) for x in others):
+            misses = {type(x).__name__
+                      for x in others
+                      if not isinstance(x, (CompositionBounds, CompositionValue))}
+            raise TypeError(f"union requires consistent typing; found {misses}")
+        result = self.components.copy()
+        for bounds in others:
+            if isinstance(bounds, CompositionValue):
+                bounds = bounds._to_bounds()
+            result.update(bounds.components)
+        return CompositionBounds(result)
+
+    def update(self, *others: Union["CompositionBounds", "CompositionValue"]):
+        """
+        Update this bounds to include other bounds.
+
+        The others list must also be Categorical Bounds or Values.
+
+        Parameters
+        ----------
+        others: Union[CategoricalBounds, CategoricalValue]
+            Other bounds or value objects to include.
+
+        """
+        self.components = self.union(*others).components
+
     def as_dict(self):
         """
         Convert bounds to a dictionary.

--- a/gemd/entity/bounds/integer_bounds.py
+++ b/gemd/entity/bounds/integer_bounds.py
@@ -84,7 +84,7 @@ class IntegerBounds(BaseBounds):
             misses = {type(x).__name__
                       for x in others
                       if not isinstance(x, (IntegerBounds, IntegerValue))}
-            raise TypeError(f"union requires consistent typing; found {misses}")
+            raise TypeError(f"union requires consistent typing; expected integer, found {misses}")
         lower = self.lower_bound
         upper = self.upper_bound
         for bounds in others:

--- a/gemd/entity/bounds/molecular_structure_bounds.py
+++ b/gemd/entity/bounds/molecular_structure_bounds.py
@@ -45,6 +45,48 @@ class MolecularStructureBounds(BaseBounds):
 
         return True
 
+    def union(self,
+              *others: Union["MolecularStructureBounds", "MolecularValue"]
+              ) -> "MolecularStructureBounds":
+        """
+        Return the union of this bounds and other bounds.
+
+        The others list must also be Molecular Structure Bounds or Values.
+
+        Parameters
+        ----------
+        others: Union[MolecularStructureBounds, MolecularValue]
+            Other bounds or value objects to include.
+
+        Returns
+        -------
+        CategoricalBounds
+            The union of this bounds and the passed bounds
+
+        """
+        from gemd.entity.value.molecular_value import MolecularValue
+
+        if any(not isinstance(x, (MolecularStructureBounds, MolecularValue)) for x in others):
+            misses = {type(x).__name__
+                      for x in others
+                      if not isinstance(x, (MolecularStructureBounds, MolecularValue))}
+            raise TypeError(f"union requires consistent typing; found {misses}")
+        return MolecularStructureBounds()
+
+    def update(self, *others: Union["MolecularStructureBounds", "MolecularValue"]):
+        """
+        Update this bounds to include other bounds.
+
+        The others list must also be Molecular Structure Bounds or Values.
+
+        Parameters
+        ----------
+        others: Union[MolecularStructureBounds, MolecularValue]
+            Other bounds or value objects to include.
+
+        """
+        pass  # This is a no-op for Molecular structure
+
     def as_dict(self):
         """
         Convert bounds to a dictionary.

--- a/gemd/entity/bounds/molecular_structure_bounds.py
+++ b/gemd/entity/bounds/molecular_structure_bounds.py
@@ -70,7 +70,8 @@ class MolecularStructureBounds(BaseBounds):
             misses = {type(x).__name__
                       for x in others
                       if not isinstance(x, (MolecularStructureBounds, MolecularValue))}
-            raise TypeError(f"union requires consistent typing; found {misses}")
+            raise TypeError(f"union requires consistent typing; "
+                            f"expected molecular structure, found {misses}")
         return MolecularStructureBounds()
 
     def update(self, *others: Union["MolecularStructureBounds", "MolecularValue"]):

--- a/gemd/entity/bounds/real_bounds.py
+++ b/gemd/entity/bounds/real_bounds.py
@@ -109,20 +109,20 @@ class RealBounds(BaseBounds):
             misses = {type(x).__name__
                       for x in others
                       if not isinstance(x, (RealBounds, ContinuousValue))}
-            raise TypeError(f"union requires consistent typing; found {misses}")
+            raise TypeError(f"union requires consistent typing; expected real, found {misses}")
         lower = self.lower_bound
         upper = self.upper_bound
         unit_ = self.default_units
         for bounds in others:
             if isinstance(bounds, ContinuousValue):
-                this_lo, this_hi = bounds._to_bounds()._convert_bounds(unit_)
-                if this_lo is None or this_hi is None:
-                    raise units.IncompatibleUnitsError(bounds.units, self.default_units)
-                bounds = RealBounds(this_lo, this_hi, default_units=self.default_units)
-            if bounds.lower_bound < lower:
-                lower = bounds.lower_bound
-            if bounds.upper_bound > upper:
-                upper = bounds.upper_bound
+                bounds: RealBounds = bounds._to_bounds()
+            bnd_lo, bnd_hi = bounds._convert_bounds(unit_)
+            if bnd_lo is None or bnd_hi is None:
+                raise units.IncompatibleUnitsError(bounds.default_units, unit_)
+            if bnd_lo < lower:
+                lower = bnd_lo
+            if bnd_hi > upper:
+                upper = bnd_hi
         return RealBounds(lower_bound=lower, upper_bound=upper, default_units=unit_)
 
     def update(self, *others: Union["RealBounds", "ContinuousValue"]):

--- a/gemd/entity/bounds/real_bounds.py
+++ b/gemd/entity/bounds/real_bounds.py
@@ -16,7 +16,7 @@ class RealBounds(BaseBounds):
     upper_bound: float
         Upper endpoint.
     default_units: str
-        A string describing the units. Units must be present and they must be parseable by Pint.
+        A string describing the units. Units must be present and parseable by Pint.
         An empty string can be used for the units of a dimensionless quantity.
 
     """
@@ -85,6 +85,62 @@ class RealBounds(BaseBounds):
             return False
 
         return bounds.lower_bound >= lower and bounds.upper_bound <= upper
+
+    def union(self, *others: Union["RealBounds", "ContinuousValue"]) -> "RealBounds":
+        """
+        Return the union of this bounds and other bounds.
+
+        The others list must also be Real Bounds or Values.
+
+        Parameters
+        ----------
+        others: Union[RealBounds, ContinuousValue]
+            Other bounds or value objects to include.
+
+        Returns
+        -------
+        RealBounds
+            The union of this bounds and the passed bounds
+
+        """
+        from gemd.entity.value.continuous_value import ContinuousValue
+
+        if any(not isinstance(x, (RealBounds, ContinuousValue)) for x in others):
+            misses = {type(x).__name__
+                      for x in others
+                      if not isinstance(x, (RealBounds, ContinuousValue))}
+            raise TypeError(f"union requires consistent typing; found {misses}")
+        lower = self.lower_bound
+        upper = self.upper_bound
+        unit_ = self.default_units
+        for bounds in others:
+            if isinstance(bounds, ContinuousValue):
+                this_lo, this_hi = bounds._to_bounds()._convert_bounds(unit_)
+                if this_lo is None or this_hi is None:
+                    raise units.IncompatibleUnitsError(bounds.units, self.default_units)
+                bounds = RealBounds(this_lo, this_hi, default_units=self.default_units)
+            if bounds.lower_bound < lower:
+                lower = bounds.lower_bound
+            if bounds.upper_bound > upper:
+                upper = bounds.upper_bound
+        return RealBounds(lower_bound=lower, upper_bound=upper, default_units=unit_)
+
+    def update(self, *others: Union["RealBounds", "ContinuousValue"]):
+        """
+        Update this bounds to include other bounds.
+
+        The others list must also be Real Bounds or Values.
+
+        Parameters
+        ----------
+        others: Union[RealBounds, ContinuousValue]
+            Other bounds or value objects to include.
+
+        """
+        result = self.union(*others)
+        self.lower_bound = result.lower_bound
+        self.upper_bound = result.upper_bound
+        self.default_units = result.default_units
 
     def _convert_bounds(self, target_units):
         """

--- a/gemd/entity/bounds/tests/test_categorical_bounds.py
+++ b/gemd/entity/bounds/tests/test_categorical_bounds.py
@@ -5,6 +5,7 @@ from gemd.json import dumps, loads
 from gemd.entity.bounds.categorical_bounds import CategoricalBounds
 from gemd.entity.bounds.real_bounds import RealBounds
 from gemd.entity.util import array_like
+from gemd.entity.value.nominal_categorical import NominalCategorical
 
 
 def test_categories():
@@ -33,10 +34,23 @@ def test_contains():
     with pytest.raises(TypeError):
         bounds.contains({"spam", "eggs"})
 
-    from gemd.entity.value import NominalCategorical
-
     assert bounds.contains(NominalCategorical("spam"))
     assert not bounds.contains(NominalCategorical("foo"))
+
+
+def test_union():
+    """Test basic union & update logic."""
+    bounds = CategoricalBounds(categories={"spam", "eggs"})
+    value = NominalCategorical("cheese")
+    assert bounds.union(value).contains(value), "Bounds didn't get new value"
+    assert bounds.union(value).contains(bounds), "Bounds didn't keep old values"
+    assert not bounds.contains(value), "Bounds got updated"
+
+    bounds.update(value)
+    assert bounds.contains(value), "Bounds didn't get updated"
+
+    with pytest.raises(TypeError):
+        bounds.union(RealBounds(0, 1, ""))
 
 
 def test_json():

--- a/gemd/entity/bounds/tests/test_composition_bounds.py
+++ b/gemd/entity/bounds/tests/test_composition_bounds.py
@@ -5,6 +5,8 @@ from gemd.json import dumps, loads
 from gemd.entity.bounds.composition_bounds import CompositionBounds
 from gemd.entity.bounds.real_bounds import RealBounds
 from gemd.entity.util import array_like
+from gemd.entity.value.empirical_formula import EmpiricalFormula
+from gemd.entity.value.nominal_composition import NominalComposition
 
 
 def test_components():
@@ -33,10 +35,23 @@ def test_contains():
     with pytest.raises(TypeError):
         bounds.contains({"spam"})
 
-    from gemd.entity.value import NominalComposition
-
     assert bounds.contains(NominalComposition({"spam": 0.2, "eggs": 0.8}))
     assert not bounds.contains(NominalComposition({"foo": 1.0}))
+
+
+def test_union():
+    """Test basic union & update logic."""
+    bounds = CompositionBounds(components={"C", "H", "O", "N"})
+    value = EmpiricalFormula("CCl4")
+    assert bounds.union(value).contains(value), "Bounds didn't get new value"
+    assert bounds.union(value).contains(bounds), "Bounds didn't keep old values"
+    assert not bounds.contains(value), "Bounds got updated"
+
+    bounds.update(value)
+    assert bounds.contains(value), "Bounds didn't get updated"
+
+    with pytest.raises(TypeError):
+        bounds.union(RealBounds(0, 1, ""))
 
 
 def test_json():

--- a/gemd/entity/bounds/tests/test_integer_bounds.py
+++ b/gemd/entity/bounds/tests/test_integer_bounds.py
@@ -3,6 +3,7 @@ import pytest
 
 from gemd.entity.bounds.integer_bounds import IntegerBounds
 from gemd.entity.bounds.real_bounds import RealBounds
+from gemd.entity.value.nominal_integer import NominalInteger
 
 
 def test_errors():
@@ -35,7 +36,22 @@ def test_contains():
     with pytest.raises(TypeError):
         int_bounds.contains([0, 1])
 
-    from gemd.entity.value import NominalInteger
-
     assert int_bounds.contains(NominalInteger(1))
     assert not int_bounds.contains(NominalInteger(5))
+
+
+def test_union():
+    """Test basic union & update logic."""
+    bounds = IntegerBounds(lower_bound=1, upper_bound=5)
+    low = NominalInteger(0)
+    high = NominalInteger(10)
+    assert bounds.union(low).contains(low), "Bounds didn't get low value"
+    assert bounds.union(high).contains(high), "Bounds didn't get high value"
+    assert bounds.union(low, high).contains(bounds), "Bounds didn't keep old values"
+    assert not bounds.contains(low), "Bounds got updated"
+
+    bounds.update(low)
+    assert bounds.contains(low), "Bounds didn't get updated"
+
+    with pytest.raises(TypeError):
+        bounds.union(RealBounds(0, 1, ""))

--- a/gemd/entity/bounds/tests/test_molecular_structure_bounds.py
+++ b/gemd/entity/bounds/tests/test_molecular_structure_bounds.py
@@ -5,6 +5,8 @@ from gemd.json import dumps, loads
 from gemd.entity.bounds.molecular_structure_bounds import MolecularStructureBounds
 from gemd.entity.bounds.real_bounds import RealBounds
 
+from gemd.entity.value import Smiles, NominalInteger
+
 
 def test_contains():
     """Test basic contains logic."""
@@ -17,10 +19,22 @@ def test_contains():
     with pytest.raises(TypeError):
         bounds.contains('InChI=1/C8H8O3/c1-11-8-4-6(5-9)2-3-7(8)10/h2-5,10H,1H3')
 
-    from gemd.entity.value import Smiles, NominalInteger
-
     assert bounds.contains(Smiles('c1(C=O)cc(OC)c(O)cc1'))
     assert not bounds.contains(NominalInteger(5))
+
+
+def test_union():
+    """Test basic union & update logic."""
+    bounds = MolecularStructureBounds()
+    value = Smiles("CCC")
+    assert bounds.union(value).contains(value), "Bounds didn't get new value"
+    assert bounds.union(value).contains(bounds), "Bounds didn't keep old values"
+
+    bounds.update(value)
+    assert bounds.contains(value), "Bounds didn't get updated"
+
+    with pytest.raises(TypeError):
+        bounds.union(RealBounds(0, 1, ""))
 
 
 def test_json():

--- a/gemd/entity/bounds/tests/test_real_bounds.py
+++ b/gemd/entity/bounds/tests/test_real_bounds.py
@@ -20,7 +20,7 @@ def test_contains():
 def test_union():
     """Test basic union & update logic."""
     bounds = RealBounds(lower_bound=1, upper_bound=5, default_units='mm')
-    low = NominalReal(0, 'm')
+    low = RealBounds(lower_bound=1, upper_bound=5, default_units='um')
     high = NominalReal(1, 'cm')
     bad = NominalReal(1, 'kg')
     assert bounds.union(low).contains(low), "Bounds didn't get low value"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 toolz==0.10.0
-pint==0.10
+pint==0.13
 sphinx==4.3.0
 sphinxcontrib-apidoc==0.3.0
 sphinx-rtd-theme==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.9.0',
+      version='1.10.0',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Citrine Informatics',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='gemd',
       },
       install_requires=[
           "toolz>=0.10.0,<1",
-          "pint>=0.10,<1",
+          "pint>=0.13,<1",
           "deprecation>=2.0.7,<3"
       ],
       extras_require={


### PR DESCRIPTION
This PR adds a method to `bounds` objects that allows computation of mergers of one or many bounds objects, or extension of a given bounds object to accept a given value.

* For ordered / range-based sets, it expands such that the new range encompasses all passed ranges.
* For unordered sets, it adds the smallest number of new elements to include all passed sets.

`union` returns a new bounds without changing the old; `update` changes the bounds in place.