### PR TITLE
Bypass conversion computation when units strings match

### DIFF
--- a/gemd/units/impl.py
+++ b/gemd/units/impl.py
@@ -66,7 +66,10 @@ def convert_units(value: float, starting_unit: str, final_unit: str) -> float:
         The converted number
 
     """
-    return _ureg.Quantity(value, starting_unit).to(final_unit).magnitude
+    if starting_unit == final_unit:
+        return value  # skip computation
+    else:
+        return _ureg.Quantity(value, starting_unit).to(final_unit).magnitude
 
 
 def change_definitions_file(filename: str = None):

--- a/gemd/units/tests/test_parser.py
+++ b/gemd/units/tests/test_parser.py
@@ -66,10 +66,10 @@ def test_file_change():
     """Test that swapping units files works."""
     assert convert_units(1, 'm', 'cm') == 100
     with pytest.raises(UndefinedUnitError):
-        assert convert_units(1, 'usd', 'usd') == 1
+        assert convert_units(1, 'usd', 'USD') == 1
     with _change_units(filename=pkg_resources.resource_filename("gemd.units",
                                                                 "tests/test_units.txt")):
         with pytest.raises(UndefinedUnitError):
             assert convert_units(1, 'm', 'cm') == 100
-        assert convert_units(1, 'usd', 'usd') == 1
+        assert convert_units(1, 'usd', 'USD') == 1
     assert convert_units(1, 'm', 'cm') == 100  # And verify we're back to normal

--- a/gemd/units/tests/test_units.txt
+++ b/gemd/units/tests/test_units.txt
@@ -1,4 +1,4 @@
 
 #### BASE UNITS ####
 
-usd = [currency]
+usd = [currency] = USD

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.10.2',
+      version='1.10.3',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Citrine Informatics',


### PR DESCRIPTION
Profiling showed some downstream applications are bottle-necked by no-op unit transformations.  This PR adds an early exit when the unit strings are equal.