### PR TITLE
Add caching for unit conversion

### DIFF
--- a/gemd/units/impl.py
+++ b/gemd/units/impl.py
@@ -47,6 +47,7 @@ def parse_units(units: Union[str, _Unit, None]) -> Union[str, _Unit, None]:
         raise UndefinedUnitError("Units must be given as a recognized unit string or Units object")
 
 
+@functools.lru_cache(maxsize=None)
 def convert_units(value: float, starting_unit: str, final_unit: str) -> float:
     """
     Convert the value from the starting_unit to the final_unit.
@@ -83,6 +84,7 @@ def change_definitions_file(filename: str = None):
 
     """
     global _ureg
+    convert_units.cache_clear()  # Units will change
     if filename is None:
         filename = DEFAULT_FILE
     _ureg = UnitRegistry(filename=filename)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.10.3',
+      version='1.10.4',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Citrine Informatics',


### PR DESCRIPTION
Add caching to `convert_units`.  Reset that caching if the units file changes.