### PR TITLE
Drop python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
 dist: bionic
 python:
-- '3.6'
-- '3.7.13'
-- '3.8.13'
+- '3.7'
+- '3.8'
 - '3.9'
-- '3.10.1'
+- '3.10'
 install:
 - pip install -U -r requirements.txt
 - pip install -U -r test_requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.10.4',
+      version='1.11.0',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Citrine Informatics',
@@ -35,7 +35,6 @@ setup(name='gemd',
       },
       classifiers=[
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',
           'Programming Language :: Python :: 3.9',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,4 +4,4 @@ pytest==6.2.5
 pydocstyle==3.0.0
 pytest-cov==3.0.0
 pytest-flake8==1.0.4
-pandas>=1.1.5,<2
+pandas==1.1.5

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,4 +4,4 @@ pytest==6.2.5
 pydocstyle==3.0.0
 pytest-cov==3.0.0
 pytest-flake8==1.0.4
-pandas==1.1.5
+pandas>=1.1.5,<2


### PR DESCRIPTION
This PR drops official support for Python 3.6 from gemd-python.  This is in line with its status as end-of-life and our other library releases.