### PR TITLE
Drop support for 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
 dist: bionic
 python:
-- '3.6'
-- '3.7.13'
-- '3.8.13'
+- '3.7'
+- '3.8'
 - '3.9'
-- '3.10.1'
+- '3.10'
 install:
 - pip install -U -r requirements.txt
 - pip install -U -r test_requirements.txt
@@ -24,7 +23,7 @@ deploy:
     local_dir: "./docs/_build/html/"
     on:
       tags: true
-      python: '3.6' # only need this to run once
+      python: '3.7' # only need this to run once
   - provider: pypi
     user: "CitrineInformatics"
     password: "$PYPI_PASSWORD"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.10.4',
+      version='1.11.0',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Citrine Informatics',
@@ -35,7 +35,6 @@ setup(name='gemd',
       },
       classifiers=[
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',
           'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
This PR drops support for Python 3.6, which has been end of life for about a year.

As per PLA-10357.