### PR TITLE
Add support for scaling factors to gemd-python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 - '3.9'
 - '3.10'
 env:
-- PINT_VERSION=0.13
+- PINT_VERSION=0.18
 - PINT_VERSION=0.20
 jobs:
   exclude:
@@ -32,7 +32,7 @@ deploy:
     on:
       tags: true
       python: '3.7' # only need this to run once
-      env: PINT_VERSION=0.13
+      env: PINT_VERSION=0.18
   - provider: pypi
     user: "CitrineInformatics"
     password: "$PYPI_PASSWORD"

--- a/gemd/units/impl.py
+++ b/gemd/units/impl.py
@@ -42,9 +42,9 @@ def _scaling_preprocessor(input_string: str) -> str:
         # There's probably something to be said for stashing these, but this sin
         # should be ameliorated by the LRU cache
         regex = rf"\b{re.escape(scale)}\b"
-        valid = "_" + scale.replace(".", "o").replace("+", "p").replace("-", "m")
+        valid = "_" + scale.replace(".", "_").replace("+", "").replace("-", "_")
         trailing = "/" if division else ""
-        registry.define(f"{scale} = {scale} = {scale} = {valid}")
+        registry.define(f"{valid} = {scale} = {scale}")
         input_string = re.sub(regex, valid + trailing, input_string)
 
     return input_string

--- a/gemd/units/tests/test_parser.py
+++ b/gemd/units/tests/test_parser.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 import pkg_resources
 from contextlib import contextmanager
@@ -28,6 +30,8 @@ def test_parse_expected():
     assert parse_units("") == 'dimensionless'
     # Scaling factors bind tightly to trailing units
     assert parse_units("g / 2.5 cm") == parse_units("g / (2.5 cm)")
+    assert parse_units("g / 2.5cm") == parse_units("g / (2.5 cm)")
+    assert parse_units("g / 25.mm") == parse_units("g / (25. mm)")
     assert parse_units("g / 2.5 * cm") == parse_units("g cm / 2.5")
 
 
@@ -48,6 +52,31 @@ def test_parse_unexpected():
 def test_parse_none():
     """Test that None parses as None."""
     assert parse_units(None) is None
+
+
+def test_format():
+    """Test that custom formatting behaves as we hope."""
+    # use the default unit registry for now
+    reg = UnitRegistry(filename=pkg_resources.resource_filename("gemd.units", "citrine_en.txt"))
+
+    result = parse_units("K^-2 m^-1 C^0 g^1 s^2")
+    assert "-" not in result
+    assert "[time]" in reg(result).dimensionality
+    assert "[current]" not in reg(result).dimensionality
+    kelvin = str(reg("K").units)
+    gram = str(reg("g").units)
+    second = str(reg("s").units)
+    assert kelvin in result
+    assert gram in result
+    assert second in result
+    assert result.index(gram) < result.index(kelvin)
+    assert result.index(gram) < result.index(second)
+
+    assert not re.search(r"\d", parse_units("m kg / s"))
+    assert "/" not in parse_units("m kg s")
+    assert "1" not in parse_units("s")
+    assert "1" in parse_units("s^-1")
+    assert "2.5" in parse_units("g / 2.5 cm")
 
 
 def test_conversion():

--- a/gemd/units/tests/test_parser.py
+++ b/gemd/units/tests/test_parser.py
@@ -20,11 +20,15 @@ def test_parse_expected():
         reg("kg").u,
         "amu",  # A line that was edited
         "Seconds",  # Added support for some title-case units
-        "delta_Celsius / hour"  # Added to make sure pint version is right (>0.10)
+        "delta_Celsius / hour",  # Added to make sure pint version is right (>0.10)
+        "g / 2.5 cm",  # Scaling factors are acceptable
     ]
     for unit in expected:
         parse_units(unit)
     assert parse_units("") == 'dimensionless'
+    # Scaling factors bind tightly to trailing units
+    assert parse_units("g / 2.5 cm") == parse_units("g / (2.5 cm)")
+    assert parse_units("g / 2.5 * cm") == parse_units("g cm / 2.5")
 
 
 def test_parse_unexpected():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 toolz==0.10.0
-pint==0.13
+pint==0.18
 sphinx==4.3.0
 sphinxcontrib-apidoc==0.3.0
 sphinx-rtd-theme==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='gemd',
       },
       install_requires=[
           "toolz>=0.10.0,<1",
-          "pint>=0.13,<0.21",
+          "pint>=0.18,<0.21",
           "deprecation>=2.0.7,<3"
       ],
       extras_require={

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.12.1',
+      version='1.12.2',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Citrine Informatics',


### PR DESCRIPTION
[Pint](https://pint.readthedocs.io) does not support scaling factors in units (e.g., [support ticket](https://github.com/hgrecco/pint/issues/793)).  In order to provide support for units encountered in the wild (e.g., `g / 2.5 cm`), this PR adds support for strictly numeric scaling factors.

It dynamically adds a dimensionless scaling unit for any number encountered (where `Number` is defined using the same tokenizer as the core Pint library).  Multiplication between a scaling factor and a unit also bind tighter than division (i.e., if that scaling factor is preceded by division and followed by a unit, it also puts that unit in the denominator).

Internal Citrine reference: https://citrine.atlassian.net/browse/PLA-6256