### PR TITLE
Fix minor serialization bugs

### DIFF
--- a/gemd/json/gemd_encoder.py
+++ b/gemd/json/gemd_encoder.py
@@ -1,4 +1,5 @@
 from json import JSONEncoder
+from uuid import UUID
 
 from gemd.entity.dict_serializable import DictSerializable
 from gemd.enumeration.base_enumeration import BaseEnumeration
@@ -13,5 +14,7 @@ class GEMDEncoder(JSONEncoder):
             return o.as_dict()
         elif isinstance(o, BaseEnumeration):
             return o.value
+        elif isinstance(o, UUID):
+            return str(o)
         else:
             return JSONEncoder.default(self, o)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.13.1',
+      version='1.13.2',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Citrine Informatics',


### PR DESCRIPTION
This PR fixes two issues with the JSON serialization:
* If `uids` or a LinkByUID contained a UUID object instead of a string, it couldn't be serialized.  Logic was added so that this are turned into strings to avoid something that's technically an error but practically easy to support.
* The `dumps` and `loads` methods were caching the state of the class map before a consuming library could create a child class.  The map is now pulled in at ser/deser time, overriding it with any classes that were manually registered.