### PR TITLE
Include periods in acceptable punctuation in units

### DIFF
--- a/gemd/units/impl.py
+++ b/gemd/units/impl.py
@@ -169,4 +169,4 @@ def change_definitions_file(filename: str = None):
     convert_units.cache_clear()  # Units will change
     if filename is None:
         filename = DEFAULT_FILE
-    _REGISTRY = UnitRegistry(filename=filename)
+    _REGISTRY = UnitRegistry(filename=filename, preprocessors=[_scaling_preprocessor])

--- a/gemd/units/impl.py
+++ b/gemd/units/impl.py
@@ -15,7 +15,7 @@ from typing import Union
 
 # use the default unit registry for now
 DEFAULT_FILE = pkg_resources.resource_filename("gemd.units", "citrine_en.txt")
-_ALLOWED_OPERATORS = {"+", "-", "*", "/", "//", "^", "**", "(", ")"}
+_ALLOWED_OPERATORS = {".", "+", "-", "*", "/", "//", "^", "**", "(", ")"}
 
 
 def _scaling_preprocessor(input_string: str) -> str:

--- a/gemd/units/tests/test_parser.py
+++ b/gemd/units/tests/test_parser.py
@@ -130,6 +130,8 @@ def test_file_change():
             assert convert_units(1, 'm', 'cm') == 100
         assert convert_units(1, 'usd', 'USD') == 1
     assert convert_units(1, 'm', 'cm') == 100  # And verify we're back to normal
+    with pytest.raises(UndefinedUnitError):
+        parse_units('mol : mol')  # Ensure the preprocessor is still there
 
 
 def test_punctuation():

--- a/gemd/units/tests/test_parser.py
+++ b/gemd/units/tests/test_parser.py
@@ -138,5 +138,3 @@ def test_punctuation():
     assert parse_units('N.m') == parse_units('N * m')
     with pytest.raises(UndefinedUnitError):
         parse_units('mol : mol')
-        import gemd.units
-        print(gemd.units.impl._ALLOWED_OPERATORS)

--- a/gemd/units/tests/test_parser.py
+++ b/gemd/units/tests/test_parser.py
@@ -130,3 +130,13 @@ def test_file_change():
             assert convert_units(1, 'm', 'cm') == 100
         assert convert_units(1, 'usd', 'USD') == 1
     assert convert_units(1, 'm', 'cm') == 100  # And verify we're back to normal
+
+
+def test_punctuation():
+    """Test that punctuation parses reasonably."""
+    assert parse_units('mol.') == parse_units('moles')
+    assert parse_units('N.m') == parse_units('N * m')
+    with pytest.raises(UndefinedUnitError):
+        parse_units('mol : mol')
+        import gemd.units
+        print(gemd.units.impl._ALLOWED_OPERATORS)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.13.2',
+      version='1.13.3',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Citrine Informatics',


### PR DESCRIPTION
Add `.` to acceptable punctuation in units.