### PR TITLE
Correct units handling for whitespace in unaries

### DIFF
--- a/gemd/units/impl.py
+++ b/gemd/units/impl.py
@@ -52,15 +52,15 @@ def _scaling_preprocessor(input_string: str) -> str:
         value = eval(substr)
         if value <= 0:
             raise DefinitionSyntaxError(f"Scaling factors must be positive: {substr}")
-        scales.append([substr, value, division and tight])
+        scales.append([substr, token.string, division and tight])
 
     for substr, value, division in scales:
         # There's probably something to be said for stashing these, but this sin
         # should be ameliorated by the LRU cache
         regex = rf"(?<!=[-+0-9.]){re.escape(substr)}(?!=[0-9.])"
-        valid = "_" + substr.replace(".", "_").replace("+", "").replace("-", "_")
+        valid = "_" + value.replace(".", "_").replace("+", "").replace("-", "_")
         trailing = "/" if division else ""
-        _REGISTRY.define(f"{valid} = {value} = {substr}")
+        _REGISTRY.define(f"{valid} = {value} = {value}")
         input_string = re.sub(regex, valid + trailing, input_string)
 
     return input_string

--- a/gemd/units/tests/test_parser.py
+++ b/gemd/units/tests/test_parser.py
@@ -28,7 +28,8 @@ def test_parse_expected():
         "Seconds",  # Added support for some title-case units
         "delta_Celsius / hour",  # Added to make sure pint version is right (>0.10)
         "g / 2.5 cm",  # Scaling factors are acceptable
-        "g / -+-25e-1 m"  # Weird but fine
+        "g / -+-25e-1 m",  # Weird but fine
+        "ug / - -250 mL"  # Spaces between unaries is acceptable
     ]
     for unit in expected:
         parse_units(unit)
@@ -67,6 +68,7 @@ def test_parse_unexpected():
         "/gram",  # A leading operator makes no sense
         "g / 0 m",  # Zero scaling factor
         "g / -2 m"  # Negative scaling factor
+        "m ** - 1"  # Pint parse doesn't accept spaces between negative & numeral / unit
     ]
     for unit in definition:
         with pytest.raises(DefinitionSyntaxError):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.13.3',
+      version='1.13.4',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Citrine Informatics',


### PR DESCRIPTION
In the strange case of embedded whitespace for unaries (e.g., `m^- -0.25`), Pint considers this fine while the scaling factor logic was creating tokens with embedded whitespace (e.g., `__ _0_25`) which caused secondary parsing issues.  This corrects for this bug, as well as creating cleaner tokens (e.g., `_0_25`).  This PR also maintains Pint's behavior when there is a space between the numeral and the first unary operator (e.g., `- 1`).

This should be the last units PR until Python 3.7 is end-of-lifed in June, at which point support for Pint 0.18 will be dropped and the parse_units method can eliminate all exception handling and just call `UnitRegistry.parse_units`.
