### PR TITLE
Boost testing range

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,16 @@ python:
 - '3.9'
 - '3.10'
 - '3.11'
+- '3.12'
 env:
 - PINT_VERSION=0.18
-- PINT_VERSION=0.20
+- PINT_VERSION=0.21
 jobs:
   exclude:
     - python: 3.7
-      env: PINT_VERSION=0.20
+      env: PINT_VERSION=0.21
+    - python: 3.12
+      env: PINT_VERSION=0.18
 install:
 - pip install -U -r requirements.txt
 - pip install Pint==$PINT_VERSION
@@ -30,8 +33,8 @@ deploy:
     local_dir: "./docs/_build/html/"
     on:
       tags: true
-      python: '3.7' # only need this to run once
-      env: PINT_VERSION=0.18
+      python: '3.10' # only need this to run once
+      env: PINT_VERSION=0.21
   - provider: pypi
     user: "CitrineInformatics"
     password: "$PYPI_PASSWORD"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='gemd',
-      version='1.13.5',
+      version='1.13.6',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Citrine Informatics',
@@ -19,7 +19,7 @@ setup(name='gemd',
       },
       install_requires=[
           "toolz>=0.10.0,<1",
-          "pint>=0.18,<0.21",
+          "pint>=0.18,<0.22",
           "deprecation>=2.0.7,<3"
       ],
       extras_require={
@@ -27,7 +27,7 @@ setup(name='gemd',
               "pytest>=6.2.5,<7"
           ],
           "gemd.demo.tests": [
-              "pandas>=1.1.5,<2"
+              "pandas>=1.3.5,<2"
           ],
           "gemd.entity.bounds.tests": [
               "numpy"
@@ -40,5 +40,6 @@ setup(name='gemd',
           'Programming Language :: Python :: 3.9',
           'Programming Language :: Python :: 3.10',
           'Programming Language :: Python :: 3.11',
+          'Programming Language :: Python :: 3.12',
       ],
       )

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,8 +1,7 @@
 flake8==3.7.8
 flake8-docstrings==1.3.1
-pytest==6.2.5
+pytest==7.3.1
 pydocstyle==3.0.0
-pytest-cov==3.0.0
-pytest-flake8==1.0.4
-pandas>=1.1.5,<2
+pytest-cov==4.0.0
+pandas>=1.3.5,<2
 derp==0.1.1


### PR DESCRIPTION
This PR adds Python 3.12 to the Travis testing, adds 0.21 to the tested Pint versions, and cleans up the testing install a bit.