### PR TITLE
Drop support for python 3.7; migrate toolz & pint accordingly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 - '3.9'
 - '3.10'
 - '3.11'
+- '3.12-dev'
 env:
   - UPGRADES="-U pint pandas"
   - UPGRADES=""

--- a/gemd/entity/value/discrete_categorical.py
+++ b/gemd/entity/value/discrete_categorical.py
@@ -1,6 +1,4 @@
 """Discrete distribution across several categories."""
-from toolz import keymap
-
 from gemd.entity.setters import validate_str
 from gemd.entity.value.categorical_value import CategoricalValue
 from gemd.entity.bounds import CategoricalBounds
@@ -41,7 +39,7 @@ class DiscreteCategorical(CategoricalValue, typ="discrete_categorical"):
         elif isinstance(probabilities, dict):
             if abs(sum(probabilities.values()) - 1.0) > 1.0e-9:
                 raise ValueError("probabilities must sum to 1.0")
-            self._probabilities = keymap(validate_str, probabilities)
+            self._probabilities = {validate_str(k): v for k, v in probabilities.items()}
         else:
             raise TypeError("probabilities must be dict or single value")
 

--- a/gemd/util/impl.py
+++ b/gemd/util/impl.py
@@ -9,8 +9,6 @@ from gemd.entity.base_entity import BaseEntity
 from gemd.entity.dict_serializable import DictSerializable
 from gemd.entity.link_by_uid import LinkByUID
 
-from toolz import concatv
-
 
 def set_uuids(obj, scope):
     """
@@ -441,8 +439,8 @@ def recursive_foreach(obj: Union[Iterable, BaseEntity, DictSerializable],
             func(this)
 
         if cached_isinstance(this, Mapping):
-            for x in concatv(this.keys(), this.values()):
-                queue.append(x)
+            queue.extend(this.keys())
+            queue.extend(this.values())
         elif cached_isinstance(this, DictSerializable):
             for k, x in this.__dict__.items():
                 queue.append(x)
@@ -496,7 +494,8 @@ def recursive_flatmap(obj: Union[Iterable, BaseEntity, DictSerializable],
             res.extend(func(this))
 
         if cached_isinstance(this, Mapping):
-            queue.extend(concatv(this.keys(), this.values()))
+            queue.extend(this.keys())
+            queue.extend(this.values())
         elif cached_isinstance(this, DictSerializable):
             for k, x in sorted(this.__dict__.items()):
                 if unidirectional and cached_isinstance(this, BaseEntity) and k in this.skip:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-toolz==0.11.0
-pint==0.18
+pint==0.19
 sphinx==4.3.0
 sphinxcontrib-apidoc==0.3.0
 sphinx-rtd-theme==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ packages = find_packages()
 packages.append("")
 
 setup(name='gemd',
-      version='1.16.2',
-      python_requires='>=3.7',
+      version='1.16.3',
+      python_requires='>=3.8',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
       author='Citrine Informatics',
@@ -23,8 +23,7 @@ setup(name='gemd',
           'tests.units': ['test_units.txt']
       },
       install_requires=[
-          "toolz>=0.11.0,<1",
-          "pint>=0.18,<1",
+          "pint>=0.19,<1",
           "deprecation>=2.1.0,<3"
       ],
       extras_require={
@@ -40,7 +39,6 @@ setup(name='gemd',
       },
       classifiers=[
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',
           'Programming Language :: Python :: 3.9',
           'Programming Language :: Python :: 3.10',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,5 +2,6 @@ flake8==3.7.8
 flake8-docstrings==1.3.1
 pytest==7.3.1
 pytest-cov==4.0.0
-pandas>=1.3.5,<=1.5.0
+pandas==1.5.0
+toolz==0.12.0
 derp==0.1.1


### PR DESCRIPTION
This PR drops support for Python 3.7 and removes it from the test suite.

It also bumps the minimum Pint version to 0.19.  0.19 fixed a bug with how unit strings are parsed but we needed to maintain support for 0.18 because that was the maximum Pint version.

It also drops toolz as a primary dependency, as toolz < 0.12 was issuing deprecation warnings.  The ways it was used in the source code were well handled by list comprehensions, and so it's now only in the test requirements.