### PR TITLE
Correct release configuration, again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ install:
 script:
 - bash scripts/run_tests.sh
 - test "$UPGRADES" != "" || test $TRAVIS_PYTHON_VERSION != "3.10" || bash scripts/build_docs.sh
+branches:
+  only:
+  - main
+  - /^v[\.0-9]+$/
 deploy:
   - provider: pages
     skip_cleanup: true

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ packages = find_packages()
 packages.append("")
 
 setup(name='gemd',
-      version='1.16.6',
+      version='1.16.7',
       python_requires='>=3.8',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",


### PR DESCRIPTION
This, combined with some changes to the [travis](https://app.travis-ci.com/github/CitrineInformatics/gemd-python/settings) app configuration, should repair the release pipeline.