### PR TITLE
Add compatibility for latest Pint release

### DIFF
--- a/gemd/units/impl.py
+++ b/gemd/units/impl.py
@@ -8,7 +8,10 @@ from tempfile import TemporaryDirectory
 from typing import Union, List, Tuple, Generator, Any
 
 from pint import UnitRegistry, Unit, register_unit_format
-from pint.compat import tokenizer
+try:  # Pint 0.23 migrated the location of this method, and augmented it
+    from pint.pint_eval import tokenizer
+except ImportError:
+    from pint.compat import tokenizer
 from tokenize import NAME, NUMBER, OP, ERRORTOKEN, TokenInfo
 # alias the error that is thrown when units are incompatible
 # this helps to isolate the dependence on pint

--- a/gemd/units/impl.py
+++ b/gemd/units/impl.py
@@ -10,7 +10,7 @@ from typing import Union, List, Tuple, Generator, Any
 from pint import UnitRegistry, Unit, register_unit_format
 try:  # Pint 0.23 migrated the location of this method, and augmented it
     from pint.pint_eval import tokenizer
-except ImportError:
+except ImportError:  # pragma: no cover
     from pint.compat import tokenizer
 from tokenize import NAME, NUMBER, OP, ERRORTOKEN, TokenInfo
 # alias the error that is thrown when units are incompatible

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
 pint==0.20
-sphinx==4.3.0
-sphinxcontrib-apidoc==0.3.0
-sphinx-rtd-theme==1.0.0
 deprecation==2.1.0

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ packages = find_packages()
 packages.append("")
 
 setup(name='gemd',
-      version='1.16.7',
+      version='1.16.8',
       python_requires='>=3.8',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",
@@ -23,7 +23,7 @@ setup(name='gemd',
           'tests.units': ['test_units.txt']
       },
       install_requires=[
-          "pint>=0.20,<0.23",
+          "pint>=0.20,<0.24",
           "deprecation>=2.1.0,<3"
       ],
       extras_require={

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,3 +5,6 @@ pytest-cov==4.0.0
 pandas==1.5.0
 toolz==0.12.0
 derp==0.1.1
+sphinx==4.3.0
+sphinxcontrib-apidoc==0.3.0
+sphinx-rtd-theme==1.0.0


### PR DESCRIPTION
Pint 0.23 migrated a method we imported, so this PR creates a conditional import so the necessary method can be imported from either path.