### PR TITLE
PLA-13739 Update Cake demo to not have dimensionless absolute quantities

### DIFF
--- a/gemd/demo/cake.py
+++ b/gemd/demo/cake.py
@@ -647,7 +647,7 @@ def make_cake_spec(tmpl=None):
         material=eggs,
         labels=['wet'],
         process=wetmix.process,
-        absolute_quantity=NominalReal(nominal=4, units='')
+        absolute_quantity=NominalReal(nominal=4, units='count')
     )
 
     vanilla = _make_material(

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ packages = find_packages()
 packages.append("")
 
 setup(name='gemd',
-      version='1.16.9',
+      version='1.17.0',
       python_requires='>=3.8',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",


### PR DESCRIPTION
[PLA-13739](https://citrine.atlassian.net/browse/PLA-13739)

Absolute quantities do not make reasonable sense as either negative numbers or dimensionless quantities.  This PR updates the cake demo to reflect this, and updates the validation filters on the absolute_quantity field to issue advisories / exceptions if specified.

[PLA-13739]: https://citrine.atlassian.net/browse/PLA-13739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ