### PR TITLE
Use API token for PyPI auth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ deploy:
       python: '3.10' # only need this to run once
       env: UPGRADES=""
   - provider: pypi
-    user: "CitrineInformatics"
-    password: "$PYPI_PASSWORD"
+    user: "__token__"
+    password: "$PYPI_API_TOKEN"
     distributions: "sdist bdist_wheel"
     skip_existing: true
     on:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ packages = find_packages()
 packages.append("")
 
 setup(name='gemd',
-      version='1.17.0',
+      version='1.17.1',
       python_requires='>=3.8',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",


### PR DESCRIPTION
PyPI deprecated username and password access a few years ago, and have now fully dropped support. This switches over to using the API token, which is itself encrypted and stored in Travis CI.