### PR TITLE
Move real/integer bounds attributes to properties

### DIFF
--- a/gemd/entity/bounds/integer_bounds.py
+++ b/gemd/entity/bounds/integer_bounds.py
@@ -10,7 +10,7 @@ __all__ = ["IntegerBounds"]
 class IntegerBounds(BaseBounds, typ="integer_bounds"):
     """Bounded subset of the integers, parameterized by a lower and upper bound."""
 
-    def __init__(self, lower_bound, upper_bound):
+    def __init__(self, lower_bound: int, upper_bound: int):
         self._lower_bound = None
         self._upper_bound = None
 
@@ -25,9 +25,9 @@ class IntegerBounds(BaseBounds, typ="integer_bounds"):
     @lower_bound.setter
     def lower_bound(self, value: int):
         """Set the lower endpoint of the permitted range."""
-        if value is None or not isfinite(value):
-            raise ValueError(f"Lower bound must be given and finite: {value}")
-        if self.upper_bound is not None and value > self.upper_bound:  # Set first
+        if value is None or not isfinite(value) or int(value) != float(value):
+            raise ValueError(f"Lower bound must be given, integer and finite: {value}")
+        if self.upper_bound is not None and value > self.upper_bound:
             raise ValueError(f"Upper bound ({self.upper_bound}) must be "
                              f"greater than or equal to lower bound ({value})")
         self._lower_bound = int(value)
@@ -40,9 +40,9 @@ class IntegerBounds(BaseBounds, typ="integer_bounds"):
     @upper_bound.setter
     def upper_bound(self, value: int):
         """Set the upper endpoint of the permitted range."""
-        if value is None or not isfinite(value):
-            raise ValueError(f"Upper bound must be given and finite: {value}")
-        if value < self.lower_bound:
+        if value is None or not isfinite(value) or int(value) != float(value):
+            raise ValueError(f"Upper bound must be given, integer and finite: {value}")
+        if self.lower_bound is not None and value < self.lower_bound:
             raise ValueError(f"Upper bound ({value}) must be "
                              f"greater than or equal to lower bound ({self.lower_bound})")
         self._upper_bound = int(value)

--- a/gemd/entity/bounds/integer_bounds.py
+++ b/gemd/entity/bounds/integer_bounds.py
@@ -1,34 +1,51 @@
 """Bounds an integer to be between two values."""
+from math import isfinite
+from typing import Union
+
 from gemd.entity.bounds.base_bounds import BaseBounds
 
-from typing import Union
+__all__ = ["IntegerBounds"]
 
 
 class IntegerBounds(BaseBounds, typ="integer_bounds"):
-    """
-    Bounded subset of the integers, parameterized by a lower and upper bound.
+    """Bounded subset of the integers, parameterized by a lower and upper bound."""
 
-    Parameters
-    ----------
-    lower_bound: int
-        Lower endpoint.
-    upper_bound: int
-        Upper endpoint.
+    def __init__(self, lower_bound, upper_bound):
+        self._lower_bound = None
+        self._upper_bound = None
 
-    """
-
-    def __init__(self, lower_bound=None, upper_bound=None):
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
 
-        if self.lower_bound is None or abs(self.lower_bound) >= float("inf"):
-            raise ValueError("Lower bound must be given and finite: {}".format(self.lower_bound))
+    @property
+    def lower_bound(self) -> int:
+        """The lower endpoint of the permitted range."""
+        return self._lower_bound
 
-        if self.upper_bound is None or abs(self.upper_bound) >= float("inf"):
-            raise ValueError("Upper bound must be given and finite")
+    @lower_bound.setter
+    def lower_bound(self, value: int):
+        """Set the lower endpoint of the permitted range."""
+        if value is None or not isfinite(value):
+            raise ValueError(f"Lower bound must be given and finite: {value}")
+        if self.upper_bound is not None and value > self.upper_bound:  # Set first
+            raise ValueError(f"Upper bound ({self.upper_bound}) must be "
+                             f"greater than or equal to lower bound ({value})")
+        self._lower_bound = int(value)
 
-        if self.upper_bound < self.lower_bound:
-            raise ValueError("Upper bound must be greater than or equal to lower bound")
+    @property
+    def upper_bound(self) -> int:
+        """The upper endpoint of the permitted range."""
+        return self._upper_bound
+
+    @upper_bound.setter
+    def upper_bound(self, value: int):
+        """Set the upper endpoint of the permitted range."""
+        if value is None or not isfinite(value):
+            raise ValueError(f"Upper bound must be given and finite: {value}")
+        if value < self.lower_bound:
+            raise ValueError(f"Upper bound ({value}) must be "
+                             f"greater than or equal to lower bound ({self.lower_bound})")
+        self._upper_bound = int(value)
 
     def contains(self, bounds: Union[BaseBounds, "BaseValue"]) -> bool:  # noqa: F821
         """

--- a/gemd/entity/bounds/real_bounds.py
+++ b/gemd/entity/bounds/real_bounds.py
@@ -1,8 +1,9 @@
 """Bound a real number to be between two values."""
+from math import isfinite
+from typing import Union
+
 from gemd.entity.bounds.base_bounds import BaseBounds
 import gemd.units as units
-
-from typing import Union
 
 
 class RealBounds(BaseBounds, typ="real_bounds"):
@@ -21,21 +22,44 @@ class RealBounds(BaseBounds, typ="real_bounds"):
 
     """
 
-    def __init__(self, lower_bound=None, upper_bound=None, default_units=None):
+    def __init__(self, lower_bound, upper_bound, default_units):
+        self._default_units = None
+        self._lower_bound = None
+        self._upper_bound = None
+
+        self.default_units = default_units
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
 
-        self._default_units = None
-        self.default_units = default_units
+    @property
+    def lower_bound(self) -> float:
+        """The lower endpoint of the permitted range."""
+        return self._lower_bound
 
-        if self.lower_bound is None or abs(self.lower_bound) >= float("inf"):
-            raise ValueError("Lower bound must be given and finite: {}".format(self.lower_bound))
+    @lower_bound.setter
+    def lower_bound(self, value: float):
+        """Set the lower endpoint of the permitted range."""
+        if value is None or not isfinite(value):
+            raise ValueError(f"Lower bound must be given and finite: {value}")
+        if self.upper_bound is not None and value > self.upper_bound:  # Set first
+            raise ValueError(f"Upper bound ({self.upper_bound}) must be "
+                             f"greater than or equal to lower bound ({value})")
+        self._lower_bound = float(value)
 
-        if self.upper_bound is None or abs(self.upper_bound) >= float("inf"):
-            raise ValueError("Upper bound must be given and finite")
+    @property
+    def upper_bound(self) -> float:
+        """The upper endpoint of the permitted range."""
+        return self._upper_bound
 
-        if self.upper_bound < self.lower_bound:
-            raise ValueError("Upper bound must be greater than or equal to lower bound")
+    @upper_bound.setter
+    def upper_bound(self, value: float):
+        """Set the upper endpoint of the permitted range."""
+        if value is None or not isfinite(value):
+            raise ValueError(f"Upper bound must be given and finite: {value}")
+        if value < self.lower_bound:
+            raise ValueError(f"Upper bound ({value}) must be "
+                             f"greater than or equal to lower bound ({self.lower_bound})")
+        self._upper_bound = float(value)
 
     @property
     def default_units(self):

--- a/gemd/entity/bounds/real_bounds.py
+++ b/gemd/entity/bounds/real_bounds.py
@@ -7,22 +7,9 @@ import gemd.units as units
 
 
 class RealBounds(BaseBounds, typ="real_bounds"):
-    """
-    Bounded subset of the real numbers, parameterized by a lower and upper bound.
+    """Bounded subset of the real numbers, parameterized by a lower and upper bound."""
 
-    Parameters
-    ----------
-    lower_bound: float
-        Lower endpoint.
-    upper_bound: float
-        Upper endpoint.
-    default_units: str
-        A string describing the units. Units must be present and parseable by Pint.
-        An empty string can be used for the units of a dimensionless quantity.
-
-    """
-
-    def __init__(self, lower_bound, upper_bound, default_units):
+    def __init__(self, lower_bound: float, upper_bound: float, default_units: str):
         self._default_units = None
         self._lower_bound = None
         self._upper_bound = None
@@ -41,7 +28,7 @@ class RealBounds(BaseBounds, typ="real_bounds"):
         """Set the lower endpoint of the permitted range."""
         if value is None or not isfinite(value):
             raise ValueError(f"Lower bound must be given and finite: {value}")
-        if self.upper_bound is not None and value > self.upper_bound:  # Set first
+        if self.upper_bound is not None and value > self.upper_bound:
             raise ValueError(f"Upper bound ({self.upper_bound}) must be "
                              f"greater than or equal to lower bound ({value})")
         self._lower_bound = float(value)
@@ -56,22 +43,28 @@ class RealBounds(BaseBounds, typ="real_bounds"):
         """Set the upper endpoint of the permitted range."""
         if value is None or not isfinite(value):
             raise ValueError(f"Upper bound must be given and finite: {value}")
-        if value < self.lower_bound:
+        if self.lower_bound is not None and value < self.lower_bound:
             raise ValueError(f"Upper bound ({value}) must be "
                              f"greater than or equal to lower bound ({self.lower_bound})")
         self._upper_bound = float(value)
 
     @property
-    def default_units(self):
-        """Get default units."""
+    def default_units(self) -> str:
+        """
+        A string describing the units.
+
+        Units must be present and parseable by Pint.
+        An empty string can be used for the units of a dimensionless quantity.
+        """
         return self._default_units
 
     @default_units.setter
-    def default_units(self, default_units):
+    def default_units(self, default_units: str):
+        """Set the string describing the units."""
         if default_units is None:
             raise ValueError("Real bounds must have units. "
                              "Use an empty string for a dimensionless quantity.")
-        self._default_units = units.parse_units(default_units)
+        self._default_units = units.parse_units(default_units, return_unit=False)
 
     def contains(self, bounds: Union[BaseBounds, "BaseValue"]) -> bool:  # noqa: F821
         """

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ packages = find_packages()
 packages.append("")
 
 setup(name='gemd',
-      version='1.17.1',
+      version='1.18.0',
       python_requires='>=3.8',
       url='http://github.com/CitrineInformatics/gemd-python',
       description="Python binding for Citrine's GEMD data model",

--- a/tests/entity/bounds/test_integer_bounds.py
+++ b/tests/entity/bounds/test_integer_bounds.py
@@ -11,11 +11,23 @@ def test_errors():
     with pytest.raises(TypeError):
         IntegerBounds()
 
+    with pytest.raises(TypeError):
+        IntegerBounds("0", 10)
+
     with pytest.raises(ValueError):
         IntegerBounds(float("-inf"), 0)
 
     with pytest.raises(ValueError):
+        IntegerBounds(0.5, 1)
+
+    with pytest.raises(ValueError):
         IntegerBounds(0, float("inf"))
+
+    with pytest.raises(ValueError):
+        IntegerBounds(0, 0.5)
+
+    with pytest.raises(TypeError):
+        IntegerBounds(0, "10")
 
     with pytest.raises(ValueError):
         IntegerBounds(10, 1)
@@ -23,6 +35,14 @@ def test_errors():
     with pytest.raises(ValueError):
         bnd = IntegerBounds(0, 1)
         bnd.lower_bound = 10
+
+    with pytest.raises(ValueError):
+        bnd = IntegerBounds(0, 1)
+        bnd.upper_bound = -1
+
+    bnd = IntegerBounds(0, 1)
+    assert bnd.lower_bound == 0
+    assert bnd.upper_bound == 1
 
 
 def test_incompatible_types():

--- a/tests/entity/bounds/test_integer_bounds.py
+++ b/tests/entity/bounds/test_integer_bounds.py
@@ -8,14 +8,21 @@ from gemd.entity.value.nominal_integer import NominalInteger
 
 def test_errors():
     """Make sure invalid bounds raise value errors."""
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         IntegerBounds()
+
+    with pytest.raises(ValueError):
+        IntegerBounds(float("-inf"), 0)
 
     with pytest.raises(ValueError):
         IntegerBounds(0, float("inf"))
 
     with pytest.raises(ValueError):
         IntegerBounds(10, 1)
+
+    with pytest.raises(ValueError):
+        bnd = IntegerBounds(0, 1)
+        bnd.lower_bound = 10
 
 
 def test_incompatible_types():

--- a/tests/entity/bounds/test_real_bounds.py
+++ b/tests/entity/bounds/test_real_bounds.py
@@ -76,6 +76,10 @@ def test_constructor_error():
         bnd = RealBounds(lower_bound=0, upper_bound=10, default_units="m")
         bnd.lower_bound = 100
 
+    bnd = RealBounds(0, 1, "m")
+    assert bnd.lower_bound == 0.0
+    assert bnd.upper_bound == 1.0
+
 
 def test_type_mismatch():
     """Test that incompatible types cannot be matched against RealBounds."""

--- a/tests/entity/bounds/test_real_bounds.py
+++ b/tests/entity/bounds/test_real_bounds.py
@@ -57,20 +57,24 @@ def test_contains_incompatible_units():
 
 def test_constructor_error():
     """Test that invalid real bounds cannot be constructed."""
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         RealBounds()
 
     with pytest.raises(ValueError):
-        RealBounds(0, float("inf"), "meter")
+        RealBounds(lower_bound=0, upper_bound=float("inf"), default_units="meter")
 
     with pytest.raises(ValueError):
-        RealBounds(None, 10, '')
+        RealBounds(lower_bound=None, upper_bound=10, default_units='')
 
     with pytest.raises(ValueError):
-        RealBounds(0, 100)
+        RealBounds(lower_bound=0, upper_bound=100, default_units=None)
 
     with pytest.raises(ValueError):
-        RealBounds(100, 0, "m")
+        RealBounds(lower_bound=100, upper_bound=0, default_units="m")
+
+    with pytest.raises(ValueError):
+        bnd = RealBounds(lower_bound=0, upper_bound=10, default_units="m")
+        bnd.lower_bound = 100
 
 
 def test_type_mismatch():


### PR DESCRIPTION
This PR migrates the lower_bound and upper_bound attributes of IntegerBounds and RealBounds objects to properties, creating getters & setters and locating validation code in those subroutines.  It also moves responsibility for verifying that required positional arguments were passed from an explicit default argument check to the compiler.

Technically breaking, since it migrates what was formerly a ValueError to a TypeError and adds setter constraints that were previously bypassed if the user modified objects.  Such objects were already considered invalid by Citrine Platform.

This should represent no meaningful change in behavior.